### PR TITLE
fix(middleware): complete missing error handling

### DIFF
--- a/backend/internal/middleware/permission.go
+++ b/backend/internal/middleware/permission.go
@@ -23,6 +23,8 @@ func (a *Auth) Permission(requiredRoles ...string) gin.HandlerFunc {
 		// Query user information
 		var user model.User
 		if err := a.db.First(&user, userID).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "No user information provided"})
+			return
 		}
 
 		// Check if user role meets requirements


### PR DESCRIPTION
## Description

This PR fixed a missing error handling in `backend/middleware/permission.go`.

If the user is not found or the database has errors when checking permission, the server should return internal server error, while avoiding error message leaking information about user existence.
