### PR TITLE
chore: remove and ignore `.vscode/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .devbox/
 .direnv/
+.vscode/
 
 frontend/node_modules
 frontend/dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-    "recommendations": []
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "CodeGPT.apiKey": "Ollama",
-    "github.copilot.chat.anthropic.tools.websearch.userLocation": {
-
-    },
-    "github.copilot.chat.commitMessageGeneration.instructions": [],
-    "workbench.browser.openLocalhostLinks": false
-}


### PR DESCRIPTION
## Description

The `.vscode/` directory is unused, and may leak sensitive information. So it is better to remove the whole directory.
