### PR TITLE
fix(i18n): localize SMTP test success notification

### DIFF
--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -221,6 +221,7 @@ export const enUS = {
     testing: "Testing...",
     testFirst: "Please enable SMTP first",
     savePasswordFirst: "Please save password first",
+    testSucceeded: "Test email has been sent",
     testFailed: "Test failed",
     commonExamples: "Common Email Service Configuration Examples",
     gmailExample: "Gmail: smtp.gmail.com:587 (TLS) or 465 (SSL)",

--- a/frontend/src/locales/zh-CN.ts
+++ b/frontend/src/locales/zh-CN.ts
@@ -208,6 +208,7 @@ export const zhCN = {
     testing: "测试中...",
     testFirst: "请先启用 SMTP",
     savePasswordFirst: "请先保存密码",
+    testSucceeded: "测试邮件已发送",
     testFailed: "测试失败",
     commonExamples: "常见邮箱服务配置示例",
     gmailExample: "Gmail: smtp.gmail.com:587 (TLS) 或 465 (SSL)",

--- a/frontend/src/pages/SMTPSettingsPage.tsx
+++ b/frontend/src/pages/SMTPSettingsPage.tsx
@@ -104,8 +104,8 @@ export function SMTPSettingsPage() {
 
     setTesting(true);
     try {
-      const response = await configApi.testSMTP();
-      toast.success(response.data.message);
+      await configApi.testSMTP();
+      toast.success(t("smtpSettings.testSucceeded"));
     } catch (error: unknown) {
       console.error("Failed to send test email:", error);
       const apiError = error as { response?: { data?: { error?: string } } };


### PR DESCRIPTION
Replace the server-provided success message with a translated toast
string so the SMTP test success notification respects the active locale.
