### PR TITLE
feat(post): restrict category/tag creation to contributor-level roles; add in-editor category creation

### DIFF
--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -94,7 +94,8 @@ func (h *Handler) Login(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Warn("failed to bind login request JSON", "err", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -163,7 +164,8 @@ func (h *Handler) Register(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Error("failed to bind registration request JSON", "err", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -260,7 +262,8 @@ func (h *Handler) UpdateProfile(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -292,7 +295,8 @@ func (h *Handler) ChangePassword(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -326,7 +330,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -364,7 +369,8 @@ func (h *Handler) UpdateEmail(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -415,7 +421,8 @@ func (h *Handler) RequestPasswordReset(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -446,7 +453,8 @@ func (h *Handler) ResendVerification(c *gin.Context) {
 		Email string `json:"email" binding:"required,email"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -469,7 +477,8 @@ func (h *Handler) ResetPassword(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/backend/internal/captcha/handler.go
+++ b/backend/internal/captcha/handler.go
@@ -2,6 +2,7 @@ package captcha
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -52,7 +53,8 @@ func (h *Handler) VerifyCaptcha(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/backend/internal/comment/handler.go
+++ b/backend/internal/comment/handler.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -49,7 +50,8 @@ func (h *Handler) CreateComment(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -159,7 +161,8 @@ func (h *Handler) UpdateCommentModerationConfig(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/backend/internal/middleware/middleware_test.go
+++ b/backend/internal/middleware/middleware_test.go
@@ -345,6 +345,25 @@ func TestPermission_UsesContextRole(t *testing.T) {
 	}
 }
 
+func TestPermission_InvalidUserIDTypeFailsClosed(t *testing.T) {
+	// A context user ID of the wrong type means internal state was set up
+	// incorrectly; Permission must abort with an error status, not panic on
+	// a bare type assertion.
+	a := NewAuth(nil, testSecret)
+	r := gin.New()
+	r.GET("/admin", func(c *gin.Context) {
+		c.Set("userID", "not-a-uint")
+		c.Next()
+	}, a.Permission(model.RoleAdmin), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 for a non-uint user ID, got %d", w.Code)
+	}
+}
+
 func TestJWTAuth_NilDBUsesTokenRole(t *testing.T) {
 	tok := signToken(t, jwt.MapClaims{
 		"user_id":          float64(3),

--- a/backend/internal/middleware/permission.go
+++ b/backend/internal/middleware/permission.go
@@ -23,7 +23,14 @@ func (a *Auth) Permission(requiredRoles ...string) gin.HandlerFunc {
 			return
 		}
 
-		userID := userIDInterface.(uint)
+		// The context value is written by JWTAuth as a uint; a value of any
+		// other type means internal state was set up incorrectly, so fail
+		// closed instead of panicking on a bare assertion.
+		userID, ok := userIDInterface.(uint)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "No user information provided"})
+			return
+		}
 
 		// Prefer the role already resolved by JWTAuth (fresh per request),
 		// falling back to a DB lookup when the context only carries the ID.

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -402,8 +402,8 @@ func (h *Handler) GetCategories(c *gin.Context) {
 // CreateCategory creates a category.
 func (h *Handler) CreateCategory(c *gin.Context) {
 	var req struct {
-		Name        string `json:"name" binding:"required"`
-		Description string `json:"description"`
+		Name        string `json:"name" binding:"required,max=100"`
+		Description string `json:"description" binding:"max=500"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -452,7 +452,7 @@ func (h *Handler) GetTags(c *gin.Context) {
 // CreateTag creates a tag.
 func (h *Handler) CreateTag(c *gin.Context) {
 	var req struct {
-		Name string `json:"name" binding:"required"`
+		Name string `json:"name" binding:"required,max=100"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -413,6 +413,10 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	category, err := h.svc.CreateCategory(c.Request.Context(), u.Role, req.Name, req.Description)
 	if err != nil {
+		if errors.Is(err, ErrBadRequest) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Category name must not be blank"})
+			return
+		}
 		if errors.Is(err, ErrForbidden) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a category"})
 			return
@@ -458,6 +462,10 @@ func (h *Handler) CreateTag(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	tag, err := h.svc.CreateTag(c.Request.Context(), u.Role, req.Name)
 	if err != nil {
+		if errors.Is(err, ErrBadRequest) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Tag name must not be blank"})
+			return
+		}
 		if errors.Is(err, ErrForbidden) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a tag"})
 			return

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -417,19 +417,16 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	category, err := h.svc.CreateCategory(c.Request.Context(), u.Role, req.Name, req.Description)
 	if err != nil {
-		if errors.Is(err, ErrBadRequest) {
+		switch {
+		case errors.Is(err, ErrBadRequest):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Category name must not be blank"})
-			return
-		}
-		if errors.Is(err, ErrForbidden) {
+		case errors.Is(err, ErrForbidden):
 			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a category"})
-			return
-		}
-		if errors.Is(err, ErrDuplicateName) {
+		case errors.Is(err, ErrDuplicateName):
 			c.JSON(http.StatusConflict, gin.H{"error": "A category with this name already exists", "code": "duplicate_name"})
-			return
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create category"})
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create category"})
 		return
 	}
 
@@ -467,19 +464,16 @@ func (h *Handler) CreateTag(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	tag, err := h.svc.CreateTag(c.Request.Context(), u.Role, req.Name)
 	if err != nil {
-		if errors.Is(err, ErrBadRequest) {
+		switch {
+		case errors.Is(err, ErrBadRequest):
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Tag name must not be blank"})
-			return
-		}
-		if errors.Is(err, ErrForbidden) {
+		case errors.Is(err, ErrForbidden):
 			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a tag"})
-			return
-		}
-		if errors.Is(err, ErrDuplicateName) {
+		case errors.Is(err, ErrDuplicateName):
 			c.JSON(http.StatusConflict, gin.H{"error": "A tag with this name already exists", "code": "duplicate_name"})
-			return
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
 		return
 	}
 

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -410,8 +410,17 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 		return
 	}
 
-	category, err := h.svc.CreateCategory(c.Request.Context(), req.Name, req.Description)
+	u, _ := middleware.CurrentUser(c)
+	category, err := h.svc.CreateCategory(c.Request.Context(), u.Role, req.Name, req.Description)
 	if err != nil {
+		if errors.Is(err, ErrForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a category"})
+			return
+		}
+		if errors.Is(err, ErrDuplicateName) {
+			c.JSON(http.StatusConflict, gin.H{"error": "A category with this name already exists", "code": "duplicate_name"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create category"})
 		return
 	}
@@ -446,8 +455,17 @@ func (h *Handler) CreateTag(c *gin.Context) {
 		return
 	}
 
-	tag, err := h.svc.CreateTag(c.Request.Context(), req.Name)
+	u, _ := middleware.CurrentUser(c)
+	tag, err := h.svc.CreateTag(c.Request.Context(), u.Role, req.Name)
 	if err != nil {
+		if errors.Is(err, ErrForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Insufficient permissions to create a tag"})
+			return
+		}
+		if errors.Is(err, ErrDuplicateName) {
+			c.JSON(http.StatusConflict, gin.H{"error": "A tag with this name already exists", "code": "duplicate_name"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
 		return
 	}

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -2,6 +2,7 @@ package post
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -136,7 +137,8 @@ func (h *Handler) CreatePost(c *gin.Context) {
 		Status     string   `json:"status"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -186,7 +188,8 @@ func (h *Handler) UpdatePost(c *gin.Context) {
 		Status     string   `json:"status"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -406,7 +409,8 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 		Description string `json:"description" binding:"max=500"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -455,7 +459,8 @@ func (h *Handler) CreateTag(c *gin.Context) {
 		Name string `json:"name" binding:"required,max=100"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/backend/internal/post/repository.go
+++ b/backend/internal/post/repository.go
@@ -348,6 +348,15 @@ func (r *gormRepository) FindOrCreateTag(ctx context.Context, name string) (*mod
 		if err == gorm.ErrRecordNotFound {
 			tag = model.Tag{Name: name}
 			if err := r.db.WithContext(ctx).Create(&tag).Error; err != nil {
+				// A concurrent request can create the tag between the lookup
+				// and the insert; the unique index then rejects our create.
+				// Recover by returning the winner instead of failing.
+				if errors.Is(err, gorm.ErrDuplicatedKey) {
+					if retryErr := r.db.WithContext(ctx).Where("name = ?", name).First(&tag).Error; retryErr != nil {
+						return nil, retryErr
+					}
+					return &tag, nil
+				}
 				return nil, err
 			}
 			return &tag, nil
@@ -382,15 +391,19 @@ func (r *gormRepository) FindAllCategories(ctx context.Context) ([]model.Categor
 }
 
 func (r *gormRepository) CreateCategory(ctx context.Context, category *model.Category) error {
-	// Fail closed on a duplicate name rather than surfacing a raw unique-index
-	// violation; the handler maps ErrDuplicateName to a clear 409.
-	var existing model.Category
-	if err := r.db.WithContext(ctx).Where("name = ?", category.Name).First(&existing).Error; err == nil {
-		return ErrDuplicateName
-	} else if err != gorm.ErrRecordNotFound {
+	// The unique index on name is the source of truth for duplicates: insert
+	// directly and translate the constraint violation (GORM maps driver
+	// errors to gorm.ErrDuplicatedKey when opened with TranslateError) into
+	// ErrDuplicateName, which the handler renders as a 409. A select-then-
+	// insert pre-check would race: two concurrent creates could both pass the
+	// check and the loser would surface as an unmapped 500.
+	if err := r.db.WithContext(ctx).Create(category).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return ErrDuplicateName
+		}
 		return err
 	}
-	return r.db.WithContext(ctx).Create(category).Error
+	return nil
 }
 
 func (r *gormRepository) FindUserByID(ctx context.Context, id uint) (*model.User, error) {

--- a/backend/internal/post/repository.go
+++ b/backend/internal/post/repository.go
@@ -345,7 +345,7 @@ func (r *gormRepository) DeleteLikesByPostID(ctx context.Context, postID uint) e
 func (r *gormRepository) FindOrCreateTag(ctx context.Context, name string) (*model.Tag, error) {
 	var tag model.Tag
 	if err := r.db.WithContext(ctx).Where("name = ?", name).First(&tag).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			tag = model.Tag{Name: name}
 			if err := r.db.WithContext(ctx).Create(&tag).Error; err != nil {
 				// A concurrent request can create the tag between the lookup

--- a/backend/internal/post/repository.go
+++ b/backend/internal/post/repository.go
@@ -382,6 +382,14 @@ func (r *gormRepository) FindAllCategories(ctx context.Context) ([]model.Categor
 }
 
 func (r *gormRepository) CreateCategory(ctx context.Context, category *model.Category) error {
+	// Fail closed on a duplicate name rather than surfacing a raw unique-index
+	// violation; the handler maps ErrDuplicateName to a clear 409.
+	var existing model.Category
+	if err := r.db.WithContext(ctx).Where("name = ?", category.Name).First(&existing).Error; err == nil {
+		return ErrDuplicateName
+	} else if err != gorm.ErrRecordNotFound {
+		return err
+	}
 	return r.db.WithContext(ctx).Create(category).Error
 }
 

--- a/backend/internal/post/routes.go
+++ b/backend/internal/post/routes.go
@@ -29,8 +29,14 @@ func (h *Handler) RegisterRoutes(api *gin.RouterGroup) {
 	api.PUT("/posts/:id", h.mw.JWTAuth(), h.UpdatePost)
 	api.DELETE("/posts/:id", h.mw.JWTAuth(), h.DeletePost)
 
-	api.POST("/categories", h.mw.JWTAuth(), h.CreateCategory)
-	api.POST("/tags", h.mw.JWTAuth(), h.CreateTag)
+	noGuest := h.mw.Permission(
+		model.RoleContributor,
+		model.RoleAuthor,
+		model.RoleAdmin,
+		model.RoleSuperAdmin,
+	)
+	api.POST("/categories", h.mw.JWTAuth(), noGuest, h.CreateCategory)
+	api.POST("/tags", h.mw.JWTAuth(), noGuest, h.CreateTag)
 
 	api.POST("/likes/:postId", h.mw.JWTAuth(), h.ToggleLike)
 

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -424,14 +424,17 @@ func TestFindOrCreateTag_UniqueIndexRaceRecovery(t *testing.T) {
 	}
 	svc := NewService(Deps{DB: db, Notifier: &fakeNotifier{}, Files: &fakeRemover{}})
 
-	db.Callback().Create().Before("gorm:create").Register("plant_conflicting_tag", func(tx *gorm.DB) {
+	callback := db.Callback().Create().Before("gorm:create")
+	if err := callback.Register("plant_conflicting_tag", func(tx *gorm.DB) {
 		if tag, ok := tx.Statement.Dest.(*model.Tag); ok && tag.Name == "golang" {
 			plant := db.Session(&gorm.Session{SkipDefaultTransaction: true})
 			if err := plant.Exec(`INSERT INTO tags (name) VALUES (?)`, tag.Name).Error; err != nil {
 				t.Errorf("plant conflicting tag: %v", err)
 			}
 		}
-	})
+	}); err != nil {
+		t.Fatalf("register plant callback: %v", err)
+	}
 
 	tag, err := svc.CreateTag(context.Background(), model.RoleContributor, "golang")
 	if err != nil {

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -2,6 +2,7 @@ package post
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -198,6 +199,69 @@ func TestCreateCategory_DuplicateNameMapping(t *testing.T) {
 	}
 	if dup.Code < 400 || dup.Code >= 500 {
 		t.Errorf("duplicate category name: expected 4xx, got %d (body=%s)", dup.Code, dup.Body.String())
+	}
+}
+
+// TestCreateCategory_BlankNameRejected verifies that blank category names are
+// rejected with ErrBadRequest and that surrounding whitespace is trimmed
+// before the name is stored, so " tech " and "tech" cannot coexist.
+func TestCreateCategory_BlankNameRejected(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"", "   ", "\t\n"} {
+		if _, err := svc.CreateCategory(ctx, model.RoleContributor, name, ""); !errors.Is(err, ErrBadRequest) {
+			t.Errorf("blank category name %q: expected ErrBadRequest, got %v", name, err)
+		}
+	}
+
+	cat, err := svc.CreateCategory(ctx, model.RoleContributor, "  tech  ", "")
+	if err != nil {
+		t.Fatalf("trimmed name should be accepted, got error: %v", err)
+	}
+	if cat.Name != "tech" {
+		t.Errorf("category name should be stored trimmed, got %q", cat.Name)
+	}
+}
+
+// TestCreateTag_BlankNameRejected mirrors TestCreateCategory_BlankNameRejected
+// for tags: blank names are rejected and whitespace is trimmed, matching the
+// normalization resolveTags already applies when saving posts.
+func TestCreateTag_BlankNameRejected(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"", "   ", "\t\n"} {
+		if _, err := svc.CreateTag(ctx, model.RoleContributor, name); !errors.Is(err, ErrBadRequest) {
+			t.Errorf("blank tag name %q: expected ErrBadRequest, got %v", name, err)
+		}
+	}
+
+	tag, err := svc.CreateTag(ctx, model.RoleContributor, "  golang  ")
+	if err != nil {
+		t.Fatalf("trimmed name should be accepted, got error: %v", err)
+	}
+	if tag.Name != "golang" {
+		t.Errorf("tag name should be stored trimmed, got %q", tag.Name)
+	}
+}
+
+// TestCreateCategory_BlankNameBadRequest verifies the HTTP mapping: a
+// whitespace-only name passes the binding:required check (it is non-empty) but
+// must surface as 400 via the service-level ErrBadRequest, not 500.
+func TestCreateCategory_BlankNameBadRequest(t *testing.T) {
+	r, db := newTestRouter(t)
+	u := seedRoleUser(t, db, model.RoleContributor)
+	token := mintToken(t, u.ID, model.RoleContributor)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/categories", strings.NewReader(`{"name":"   "}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("whitespace-only category name: expected 400, got %d (body=%s)", w.Code, w.Body.String())
 	}
 }
 

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -266,6 +266,31 @@ func TestCreateCategory_BlankNameBadRequest(t *testing.T) {
 	}
 }
 
+// TestCreateCategory_BindingErrorDoesNotLeakDetails verifies that a malformed
+// request body surfaces the generic 400 message; the raw validator error
+// (field names, binding rules) is logged server-side, not echoed to clients.
+func TestCreateCategory_BindingErrorDoesNotLeakDetails(t *testing.T) {
+	r, db := newTestRouter(t)
+	u := seedRoleUser(t, db, model.RoleContributor)
+	token := mintToken(t, u.ID, model.RoleContributor)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/categories", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("empty body: expected 400, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Invalid request payload") {
+		t.Errorf("expected generic error message, got %s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "required") {
+		t.Errorf("binding error details must not be echoed to clients, got %s", w.Body.String())
+	}
+}
+
 // TestCreateCategory_LengthLimits verifies the handler-side caps that mirror
 // the model constraints (name size:100): 100 characters is accepted, 101 is
 // rejected with 400, and a description over 500 characters is rejected with

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -1,0 +1,304 @@
+package post
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vexgo-org/vexgo/backend/internal/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/golang-jwt/jwt/v5"
+	"gorm.io/gorm"
+)
+
+// testJWTSecret is the shared secret used to mint tokens for the route tests.
+// It must match the secret passed to the handler's middleware.
+var testJWTSecret = []byte("issue20-route-test-secret")
+
+// newTestRouter builds a fresh gin engine with the real post routes registered
+// and a seeded user database. It returns the engine and the underlying DB so
+// callers can inspect persisted rows.
+func newTestRouter(t *testing.T) (*gin.Engine, *gorm.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.User{}, &model.Category{}, &model.Tag{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	h := NewHandler(Deps{DB: db, JWTSecret: testJWTSecret})
+	r := gin.New()
+	api := r.Group("/api")
+	h.RegisterRoutes(api)
+	return r, db
+}
+
+// mintToken signs a JWT for the given user using the route-test secret. The
+// claims mirror what JWTAuth expects: user_id, username, role, a
+// password_version matching the seeded user, and an iat that is newer than the
+// user's (zero) LastLoginAt so the token is accepted.
+func mintToken(t *testing.T, userID uint, role string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"user_id":          float64(userID),
+		"username":         "tester",
+		"role":             role,
+		"password_version": float64(1),
+		"iat":              float64(time.Now().Unix()),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(testJWTSecret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+func seedRoleUser(t *testing.T, db *gorm.DB, role string) model.User {
+	t.Helper()
+	u := model.User{Username: "u_" + role, Email: "u_" + role + "@example.com", Role: role, PasswordVersion: 1}
+	if err := db.Create(&u).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return u
+}
+
+func doPostCategory(t *testing.T, r *gin.Engine, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := strings.NewReader(`{"name":"tech","description":""}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/categories", body)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func doPostTag(t *testing.T, r *gin.Engine, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := strings.NewReader(`{"name":"golang"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tags", body)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestCreateCategory_RoleGating exercises the AC1 acceptance criteria against
+// the real middleware+handler chain. guest and unknown roles are expected to be
+// rejected with 403, the four contributor-level roles with 201, and anonymous
+// requests with 401. Until the routes are gated (issue step 1) the guest /
+// unknown / anonymous expectations fail.
+func TestCreateCategory_RoleGating(t *testing.T) {
+	cases := []struct {
+		name     string
+		role     string // "" means no token at all
+		wantCode int
+	}{
+		{"anonymous", "", http.StatusUnauthorized}, // 401 (already enforced by JWTAuth)
+		{"guest", model.RoleGuest, http.StatusForbidden},
+		{"contributor", model.RoleContributor, http.StatusCreated},
+		{"author", model.RoleAuthor, http.StatusCreated},
+		{"admin", model.RoleAdmin, http.StatusCreated},
+		{"super_admin", model.RoleSuperAdmin, http.StatusCreated},
+		{"unknown_role", "wizard", http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, db := newTestRouter(t)
+			var token string
+			if tc.role != "" {
+				u := seedRoleUser(t, db, tc.role)
+				token = mintToken(t, u.ID, tc.role)
+			}
+			w := doPostCategory(t, r, token)
+			if w.Code != tc.wantCode {
+				t.Errorf("POST /api/categories role=%q: expected %d, got %d (body=%s)",
+					tc.role, tc.wantCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestCreateTag_RoleGating mirrors TestCreateCategory_RoleGating for tags.
+func TestCreateTag_RoleGating(t *testing.T) {
+	cases := []struct {
+		name     string
+		role     string
+		wantCode int
+	}{
+		{"anonymous", "", http.StatusUnauthorized},
+		{"guest", model.RoleGuest, http.StatusForbidden},
+		{"contributor", model.RoleContributor, http.StatusCreated},
+		{"author", model.RoleAuthor, http.StatusCreated},
+		{"admin", model.RoleAdmin, http.StatusCreated},
+		{"super_admin", model.RoleSuperAdmin, http.StatusCreated},
+		{"unknown_role", "wizard", http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, db := newTestRouter(t)
+			var token string
+			if tc.role != "" {
+				u := seedRoleUser(t, db, tc.role)
+				token = mintToken(t, u.ID, tc.role)
+			}
+			w := doPostTag(t, r, token)
+			if w.Code != tc.wantCode {
+				t.Errorf("POST /api/tags role=%q: expected %d, got %d (body=%s)",
+					tc.role, tc.wantCode, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestCreateCategory_DuplicateNameMapping asserts that creating a category with
+// a name that already exists returns a clear 4xx rather than 500. The exact
+// status (400 validation or 409 conflict) is left open, but a 500 would be a
+// silent server error and 201 would mean the duplicate was allowed. Requires
+// the duplicate handling from issue step 3, which is not implemented yet, so
+// this is expected to be red.
+func TestCreateCategory_DuplicateNameMapping(t *testing.T) {
+	r, db := newTestRouter(t)
+	u := seedRoleUser(t, db, model.RoleContributor)
+	token := mintToken(t, u.ID, model.RoleContributor)
+
+	// First creation succeeds (or at least does not error fatally).
+	first := doPostCategory(t, r, token)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first category creation expected 201, got %d (body=%s)", first.Code, first.Body.String())
+	}
+
+	// Second creation with the same name must surface a clear 4xx, not 500 and
+	// not a second 201.
+	dup := doPostCategory(t, r, token)
+	if dup.Code == http.StatusCreated {
+		t.Errorf("duplicate category name: expected rejection, got 201 (body=%s)", dup.Body.String())
+	}
+	if dup.Code < 400 || dup.Code >= 500 {
+		t.Errorf("duplicate category name: expected 4xx, got %d (body=%s)", dup.Code, dup.Body.String())
+	}
+}
+
+// TestCreateCategory_ServiceRoleCheck verifies AC2 at the service layer: the
+// service must reject non-contributor roles (fail closed) even when no
+// middleware is involved. model.IsContributor covers contributor/author/admin/
+// super_admin; guest and an empty role must be rejected. This currently passes
+// because the service already calls model.IsContributor, but pins the contract.
+func TestCreateCategory_ServiceRoleCheck(t *testing.T) {
+	for _, role := range []string{
+		model.RoleGuest,
+		"",
+		model.RoleContributor,
+		model.RoleAuthor,
+		model.RoleAdmin,
+		model.RoleSuperAdmin,
+	} {
+		t.Run(role, func(t *testing.T) {
+			svc, _, _, _ := newTestService(t)
+			ctx := context.Background()
+			_, err := svc.CreateCategory(ctx, role, "cat_"+role, "desc")
+			if model.IsContributor(role) {
+				if err != nil {
+					t.Errorf("role %q should be allowed, got error: %v", role, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("role %q should be rejected (fail closed), got nil error", role)
+			}
+		})
+	}
+}
+
+// TestCreateTag_ServiceRoleCheck mirrors TestCreateCategory_ServiceRoleCheck for
+// tags (AC2, service layer).
+func TestCreateTag_ServiceRoleCheck(t *testing.T) {
+	for _, role := range []string{
+		model.RoleGuest,
+		"",
+		model.RoleContributor,
+		model.RoleAuthor,
+		model.RoleAdmin,
+		model.RoleSuperAdmin,
+	} {
+		t.Run(role, func(t *testing.T) {
+			svc, _, _, _ := newTestService(t)
+			ctx := context.Background()
+			_, err := svc.CreateTag(ctx, role, "tag_"+role)
+			if model.IsContributor(role) {
+				if err != nil {
+					t.Errorf("role %q should be allowed, got error: %v", role, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("role %q should be rejected (fail closed), got nil error", role)
+			}
+		})
+	}
+}
+
+// TestCreateCategory_HandlerFailClosedNoMiddleware verifies AC2 at the HTTP
+// layer when the Permission middleware is NOT present: the handler must still
+// map a non-contributor service rejection to 403. This is currently RED because
+// the service returns the wrong sentinel (ErrGuestViewDenied) and the handler
+// maps every error to 500, so an authenticated guest receives 500 instead of
+// 403.
+func TestCreateCategory_HandlerFailClosedNoMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.User{}, &model.Category{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	guest := seedRoleUser(t, db, model.RoleGuest)
+	token := mintToken(t, guest.ID, model.RoleGuest)
+
+	// Register the route with ONLY JWTAuth (no Permission middleware), so the
+	// handler must enforce the role check itself.
+	h := NewHandler(Deps{DB: db, JWTSecret: testJWTSecret})
+	r := gin.New()
+	r.POST("/api/categories", h.mw.JWTAuth(), h.CreateCategory)
+
+	body := strings.NewReader(`{"name":"tech","description":""}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/categories", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("authenticated guest without Permission middleware: expected 403, got %d (body=%s)",
+			w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -265,6 +265,57 @@ func TestCreateCategory_BlankNameBadRequest(t *testing.T) {
 	}
 }
 
+// TestCreateCategory_LengthLimits verifies the handler-side caps that mirror
+// the model constraints (name size:100): 100 characters is accepted, 101 is
+// rejected with 400, and a description over 500 characters is rejected with
+// 400 instead of failing at the database layer with a 500.
+func TestCreateCategory_LengthLimits(t *testing.T) {
+	r, db := newTestRouter(t)
+	u := seedRoleUser(t, db, model.RoleContributor)
+	token := mintToken(t, u.ID, model.RoleContributor)
+
+	postCategory := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/categories", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	name100 := strings.Repeat("a", 100)
+	name101 := strings.Repeat("a", 101)
+	desc501 := strings.Repeat("d", 501)
+
+	if w := postCategory(`{"name":"` + name100 + `"}`); w.Code != http.StatusCreated {
+		t.Errorf("100-char name: expected 201, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if w := postCategory(`{"name":"` + name101 + `"}`); w.Code != http.StatusBadRequest {
+		t.Errorf("101-char name: expected 400, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if w := postCategory(`{"name":"ok","description":"` + desc501 + `"}`); w.Code != http.StatusBadRequest {
+		t.Errorf("501-char description: expected 400, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateTag_LengthLimit verifies the tag name cap matching the model's
+// size:100 constraint: 101 characters must be rejected with 400.
+func TestCreateTag_LengthLimit(t *testing.T) {
+	r, db := newTestRouter(t)
+	u := seedRoleUser(t, db, model.RoleContributor)
+	token := mintToken(t, u.ID, model.RoleContributor)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tags", strings.NewReader(`{"name":"`+strings.Repeat("t", 101)+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("101-char tag name: expected 400, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
 // TestCreateCategory_ServiceRoleCheck verifies AC2 at the service layer: the
 // service must reject non-contributor roles (fail closed) even when no
 // middleware is involved. model.IsContributor covers contributor/author/admin/

--- a/backend/internal/post/routes_test.go
+++ b/backend/internal/post/routes_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func newTestRouter(t *testing.T) (*gin.Engine, *gorm.DB) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
@@ -375,6 +376,53 @@ func TestCreateTag_ServiceRoleCheck(t *testing.T) {
 	}
 }
 
+// TestFindOrCreateTag_UniqueIndexRaceRecovery simulates the concurrent-create
+// race deterministically: a before-create GORM callback plants the conflicting
+// tag between FindOrCreateTag's lookup and its insert, forcing the create to
+// hit the unique index. The plant runs on a separate session so it survives
+// the outer create's transaction rollback, mirroring a genuinely concurrent
+// insert on another connection (hence the file-backed database, since :memory:
+// is per-connection). FindOrCreateTag must recover by returning the existing
+// row instead of an error.
+func TestFindOrCreateTag_UniqueIndexRaceRecovery(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "tags.db")), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(2)
+	if err := db.AutoMigrate(&model.Tag{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	svc := NewService(Deps{DB: db, Notifier: &fakeNotifier{}, Files: &fakeRemover{}})
+
+	db.Callback().Create().Before("gorm:create").Register("plant_conflicting_tag", func(tx *gorm.DB) {
+		if tag, ok := tx.Statement.Dest.(*model.Tag); ok && tag.Name == "golang" {
+			plant := db.Session(&gorm.Session{SkipDefaultTransaction: true})
+			if err := plant.Exec(`INSERT INTO tags (name) VALUES (?)`, tag.Name).Error; err != nil {
+				t.Errorf("plant conflicting tag: %v", err)
+			}
+		}
+	})
+
+	tag, err := svc.CreateTag(context.Background(), model.RoleContributor, "golang")
+	if err != nil {
+		t.Fatalf("FindOrCreateTag should recover from a concurrent create, got error: %v", err)
+	}
+	if tag.Name != "golang" {
+		t.Errorf("recovered tag should be the existing row, got %q", tag.Name)
+	}
+
+	var count int64
+	db.Model(&model.Tag{}).Count(&count)
+	if count != 1 {
+		t.Errorf("expected exactly 1 tag row after race, got %d", count)
+	}
+}
+
 // TestCreateCategory_HandlerFailClosedNoMiddleware verifies AC2 at the HTTP
 // layer when the Permission middleware is NOT present: the handler must still
 // map a non-contributor service rejection to 403. This is currently RED because
@@ -383,7 +431,7 @@ func TestCreateTag_ServiceRoleCheck(t *testing.T) {
 // 403.
 func TestCreateCategory_HandlerFailClosedNoMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}

--- a/backend/internal/post/service.go
+++ b/backend/internal/post/service.go
@@ -21,6 +21,8 @@ var (
 	ErrGuestViewDenied = errors.New("guest view denied")
 	// ErrBadRequest means the request is invalid for the current state.
 	ErrBadRequest = errors.New("bad request")
+	// ErrDuplicateName means a category or tag with the same name already exists.
+	ErrDuplicateName = errors.New("duplicate name")
 )
 
 // Deps holds the dependencies required by the post domain.

--- a/backend/internal/post/service_category.go
+++ b/backend/internal/post/service_category.go
@@ -15,7 +15,11 @@ func (s *Service) Categories(ctx context.Context, userRole string) ([]model.Cate
 }
 
 // CreateCategory creates a category.
-func (s *Service) CreateCategory(ctx context.Context, name, description string) (*model.Category, error) {
+func (s *Service) CreateCategory(ctx context.Context, role, name, description string) (*model.Category, error) {
+	if !model.IsContributor(role) {
+		return nil, ErrForbidden
+	}
+
 	category := &model.Category{Name: name, Description: description}
 	if err := s.repo.CreateCategory(ctx, category); err != nil {
 		return nil, err

--- a/backend/internal/post/service_category.go
+++ b/backend/internal/post/service_category.go
@@ -2,6 +2,7 @@ package post
 
 import (
 	"context"
+	"strings"
 
 	"github.com/vexgo-org/vexgo/backend/internal/model"
 )
@@ -14,10 +15,17 @@ func (s *Service) Categories(ctx context.Context, userRole string) ([]model.Cate
 	return s.repo.FindAllCategories(ctx)
 }
 
-// CreateCategory creates a category.
+// CreateCategory creates a category. The name is trimmed; a blank name after
+// trimming is rejected so whitespace-only input cannot bypass the unique
+// index or create invisible near-duplicates.
 func (s *Service) CreateCategory(ctx context.Context, role, name, description string) (*model.Category, error) {
 	if !model.IsContributor(role) {
 		return nil, ErrForbidden
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, ErrBadRequest
 	}
 
 	category := &model.Category{Name: name, Description: description}

--- a/backend/internal/post/service_tag.go
+++ b/backend/internal/post/service_tag.go
@@ -16,7 +16,10 @@ func (s *Service) Tags(ctx context.Context, userRole string) ([]model.Tag, error
 }
 
 // CreateTag creates a tag.
-func (s *Service) CreateTag(ctx context.Context, name string) (*model.Tag, error) {
+func (s *Service) CreateTag(ctx context.Context, role, name string) (*model.Tag, error) {
+	if !model.IsContributor(role) {
+		return nil, ErrForbidden
+	}
 	return s.repo.FindOrCreateTag(ctx, name)
 }
 

--- a/backend/internal/post/service_tag.go
+++ b/backend/internal/post/service_tag.go
@@ -15,10 +15,17 @@ func (s *Service) Tags(ctx context.Context, userRole string) ([]model.Tag, error
 	return s.repo.FindAllTags(ctx)
 }
 
-// CreateTag creates a tag.
+// CreateTag creates a tag. The name is trimmed, matching resolveTags, so
+// leading/trailing whitespace cannot create near-duplicates of an existing
+// tag; a blank name after trimming is rejected.
 func (s *Service) CreateTag(ctx context.Context, role, name string) (*model.Tag, error) {
 	if !model.IsContributor(role) {
 		return nil, ErrForbidden
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, ErrBadRequest
 	}
 	return s.repo.FindOrCreateTag(ctx, name)
 }

--- a/backend/internal/post/service_test.go
+++ b/backend/internal/post/service_test.go
@@ -33,7 +33,9 @@ func (f *fakeRemover) Delete(url string) error {
 
 func newTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	// TranslateError mirrors the production gorm.Config (internal/database),
+	// so unique-index violations surface as gorm.ErrDuplicatedKey.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}

--- a/backend/internal/settings/handler.go
+++ b/backend/internal/settings/handler.go
@@ -53,7 +53,8 @@ func (h *Handler) UpdateSMTPConfig(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -132,7 +133,8 @@ func (h *Handler) UpdateGeneralSettings(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -177,7 +179,8 @@ func (h *Handler) UpdateAIConfig(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -294,7 +297,8 @@ func (h *Handler) UpdateThemeConfig(c *gin.Context) {
 		ActiveTheme string `json:"activeTheme" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -77,7 +78,8 @@ func (h *Handler) UpdateUserRole(c *gin.Context) {
 		Role string `json:"role" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -157,7 +159,8 @@ func (h *Handler) ApplyForCreator(c *gin.Context) {
 		Reason string `json:"reason"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 
@@ -267,7 +270,8 @@ func (h *Handler) ReviewCreatorApplication(c *gin.Context) {
 		Reason string `json:"reason"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		slog.Warn("invalid request payload", "path", c.Request.URL.Path, "err", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
 		return
 	}
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -165,9 +165,76 @@ Same guest-visibility rules as `/categories`.
 
 ---
 
-### GET /stats
+### POST /categories
 
-Get aggregate site statistics.
+Create a new category. Requires authentication, and the caller must be a contributor or above (`contributor`, `author`, `admin`, `super_admin`). The `guest` role and anonymous requests are rejected.
+
+**Request:**
+
+```json
+{
+  "name": "tech",
+  "description": "Technology-related posts"
+}
+```
+
+`name` is required; `description` is optional. Category names must be unique.
+
+**Error Responses:**
+
+- `401`: `{"error": "No authentication information provided"}` (missing/invalid token)
+- `403`: `{"error": "Insufficient permissions to create a category"}` (guest role or insufficient role)
+- `409`: `{"error": "A category with this name already exists", "code": "duplicate_name"}` (duplicate name)
+- `400`: `{"error": "..."}` (missing/invalid `name`)
+
+**Response (201):**
+
+```json
+{
+  "message": "Category created successfully",
+  "category": {
+    "id": 3,
+    "name": "tech",
+    "description": "Technology-related posts"
+  }
+}
+```
+
+---
+
+### POST /tags
+
+Create a new tag. Requires authentication, and the caller must be a contributor or above (`contributor`, `author`, `admin`, `super_admin`). The `guest` role and anonymous requests are rejected.
+
+**Request:**
+
+```json
+{
+  "name": "golang"
+}
+```
+
+`name` is required and uniquely identifies the tag.
+
+**Error Responses:**
+
+- `401`: `{"error": "No authentication information provided"}` (missing/invalid token)
+- `403`: `{"error": "Insufficient permissions to create a tag"}` (guest role or insufficient role)
+- `409`: `{"error": "A tag with this name already exists", "code": "duplicate_name"}` (duplicate name)
+- `400`: `{"error": "..."}` (missing/invalid `name`)
+
+**Response (201):**
+
+```json
+{
+  "message": "Tag created successfully",
+  "tag": { "id": 4, "name": "golang" }
+}
+```
+
+---
+
+### GET /stats
 
 **Response:**
 

--- a/docs/zh-cn/reference/api.md
+++ b/docs/zh-cn/reference/api.md
@@ -165,6 +165,71 @@
 
 ---
 
+### POST /categories
+
+创建新分类。需要登录，且调用者必须是贡献者及以上角色（`contributor`、`author`、`admin`、`super_admin`）。`guest` 角色与未登录请求将被拒绝。
+
+**请求：**
+
+```json
+{
+  "name": "tech",
+  "description": "技术相关文章"
+}
+```
+
+`name` 为必填；`description` 为选填。分类名称必须唯一。
+
+**错误响应：**
+
+- `401`：`{"error": "No authentication information provided"}`（缺少或无效的令牌）
+- `403`：`{"error": "Insufficient permissions to create a category"}`（角色为 guest 或权限不足）
+- `409`：`{"error": "A category with this name already exists", "code": "duplicate_name"}`（名称重复）
+- `400`：`{"error": "..."}`（`name` 缺失或无效）
+
+**响应（201）：**
+
+```json
+{
+  "message": "Category created successfully",
+  "category": { "id": 3, "name": "tech", "description": "技术相关文章" }
+}
+```
+
+---
+
+### POST /tags
+
+创建新标签。需要登录，且调用者必须是贡献者及以上角色（`contributor`、`author`、`admin`、`super_admin`）。`guest` 角色与未登录请求将被拒绝。
+
+**请求：**
+
+```json
+{
+  "name": "golang"
+}
+```
+
+`name` 为必填，且唯一标识一个标签。
+
+**错误响应：**
+
+- `401`：`{"error": "No authentication information provided"}`（缺少或无效的令牌）
+- `403`：`{"error": "Insufficient permissions to create a tag"}`（角色为 guest 或权限不足）
+- `409`：`{"error": "A tag with this name already exists", "code": "duplicate_name"}`（名称重复）
+- `400`：`{"error": "..."}`（`name` 缺失或无效）
+
+**响应（201）：**
+
+```json
+{
+  "message": "Tag created successfully",
+  "tag": { "id": 4, "name": "golang" }
+}
+```
+
+---
+
 ### GET /stats
 
 获取站点聚合统计。

--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -917,6 +917,11 @@ export const enUS = {
     slugTaken:
       "This slug is already taken by another post. Please choose a different one.",
     generateSlug: "Generate from title",
+    createCategory: "Create Category",
+    newCategoryPlaceholder: "New category name",
+    categoryCreateError: "Failed to create category",
+    categoryDuplicate: "A category with this name already exists",
+    categoryCreateForbidden: "You do not have permission to create categories",
   },
 
   // Notification Center Page

--- a/frontend/src/locales/zh-CN.ts
+++ b/frontend/src/locales/zh-CN.ts
@@ -880,6 +880,11 @@ export const zhCN = {
     slugRequired: "请输入 URL 别名",
     slugTaken: "该别名已被其他文章使用，请选择其他别名。",
     generateSlug: "从标题生成",
+    createCategory: "新建分类",
+    newCategoryPlaceholder: "新分类名称",
+    categoryCreateError: "创建分类失败",
+    categoryDuplicate: "该分类名称已存在",
+    categoryCreateForbidden: "你没有创建分类的权限",
   },
 
   // 通知中心页面

--- a/frontend/src/pages/WritePostPage.tsx
+++ b/frontend/src/pages/WritePostPage.tsx
@@ -91,6 +91,8 @@ export function WritePostPage() {
   const [categories, setCategories] = useState<Category[]>([]);
   const [saving, setSaving] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState("");
+  const [creatingCategory, setCreatingCategory] = useState(false);
 
   // Determine the user role
   const isContributor = user?.role === "contributor";
@@ -339,6 +341,40 @@ export function WritePostPage() {
     }
   };
 
+  const canCreateCategory = isAuthenticated && !!user && user.role !== "guest";
+  const handleCreateCategory = async () => {
+    const name = newCategoryName.trim();
+    if (!name) {
+      return;
+    }
+    setCreatingCategory(true);
+
+    try {
+      const res = await categoriesApi.createCategory({ name, description: "" });
+      const created = res.data.category;
+      const normalized = { ...created, id: String(created.id) };
+      setCategories((prev) => [...prev, normalized]);
+      setCategory(normalized.name);
+      setNewCategoryName("");
+    } catch (err) {
+      if (isAxiosError<{ error?: string; code?: string }>(err)) {
+        if (err.response?.status === 409) {
+          alert(t("writePostPage.categoryDuplicate"));
+        } else if (err.response?.status === 403) {
+          alert(t("writePostPage.categoryCreateForbidden"));
+        } else if (err.response?.status === 400 && err.response.data?.error) {
+          alert(err.response.data.error);
+        } else {
+          alert(t("writePostPage.categoryCreateError"));
+        }
+      } else {
+        alert(t("writePostPage.categoryCreateError"));
+      }
+    } finally {
+      setCreatingCategory(false);
+    }
+  };
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       {/* Form */}
@@ -444,6 +480,34 @@ export function WritePostPage() {
                 ))}
               </SelectContent>
             </Select>
+            {canCreateCategory && (
+              <div className="mt-2 flex gap-2">
+                <Input
+                  placeholder={t("writePostPage.newCategoryPlaceholder")}
+                  value={newCategoryName}
+                  onChange={(e) => setNewCategoryName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      handleCreateCategory();
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCreateCategory}
+                  disabled={creatingCategory}
+                >
+                  {creatingCategory ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Plus className="w-4 h-4 mr-2" />
+                  )}
+                  {t("writePostPage.createCategory")}
+                </Button>
+              </div>
+            )}
           </div>
 
           {/* Tags */}


### PR DESCRIPTION
## Description

This PR fixed #20.

## Changes

- **feat(post): restrict category/tag creation to contributor-level roles**
- **test(post): create tests for category and tag creation**
- **docs(api): introduce API usages of `POST /categories` and `POST /tags`**
- **feat(frontend): add in-editor category creation**

## Future Work

Currently, category modification and deletion functions are not implemented yet, and categories are shared globally.

In a multi-users scenario, every authenticated user can create categories and these categories can be used by others. So normal users can not modify or delete a category as it may affect other users' posts without permission.

Therefore, we may consider an owner model to address this problem in future development, where users have full controls over categories created and managed by themselves.
