### PR TITLE
feat(database): support MariaDB by reusing the MySQL driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ DATA_DIR=./data
 BASE_URL=https://vexgo.example.com
 
 # ==================== Database Configuration ====================
-# Database type (default: sqlite, options: sqlite, mysql, postgres)
+# Database type (default: sqlite, options: sqlite, mysql, postgres, mariadb)
 DB_TYPE=sqlite
 
 # ==================== MySQL / PostgreSQL settings (only required when not using sqlite) ====================

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ trusted_proxies: []
 # ==================== Database Configuration ====================
 
 # Database type
-# Options: "sqlite", "mysql", "postgres"
+# Options: "sqlite", "mysql", "postgres", "mariadb"
 db_type: "sqlite"
 
-# When db_type is "mysql", configure the following parameters
+# When db_type is "mysql" or "mariadb", configure the following parameters
 # db_host: "127.0.0.1"
 # db_port: 3306
 # db_user: "your_username"
@@ -316,15 +316,15 @@ You can also configure the application using environment variables.
 
 #### Database
 
-| Variable      | Default   | Description                                     |
-| ------------- | --------- | ----------------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | Database type: `sqlite`, `mysql`, or `postgres` |
-| `DB_HOST`     | —         | Database host (required for mysql/postgres)     |
-| `DB_PORT`     | —         | Database port (required for mysql/postgres)     |
-| `DB_USER`     | —         | Database username (required for mysql/postgres) |
-| `DB_PASSWORD` | —         | Database password (required for mysql/postgres) |
-| `DB_NAME`     | —         | Database name (required for mysql/postgres)     |
-| `DB_SSL_MODE` | `disable` | SSL mode for postgres                           |
+| Variable      | Default   | Description                                                |
+| ------------- | --------- | ---------------------------------------------------------- |
+| `DB_TYPE`     | `sqlite`  | Database type: `sqlite`, `mysql`, `postgres`, or `mariadb` |
+| `DB_HOST`     | —         | Database host (required for mysql/postgres)                |
+| `DB_PORT`     | —         | Database port (required for mysql/postgres)                |
+| `DB_USER`     | —         | Database username (required for mysql/postgres)            |
+| `DB_PASSWORD` | —         | Database password (required for mysql/postgres)            |
+| `DB_NAME`     | —         | Database name (required for mysql/postgres)                |
+| `DB_SSL_MODE` | `disable` | SSL mode for postgres                                      |
 
 #### SSO / Single Sign-On
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -184,10 +184,10 @@ trusted_proxies: []
 # ==================== 数据库配置 ====================
 
 # 数据库类型
-# 可选值: "sqlite", "mysql", "postgres"
+# 可选值: "sqlite", "mysql", "postgres", "mariadb"
 db_type: "sqlite"
 
-# 当 db_type 为 "mysql" 时，配置以下参数
+# 当 db_type 为 "mysql" 或 "mariadb" 时，配置以下参数
 # db_host: "127.0.0.1"
 # db_port: 3306
 # db_user: "your_username"
@@ -316,15 +316,15 @@ s3_disable_bucket_in_custom_url: false
 
 #### Database
 
-| 变量          | 默认值    | 说明                                      |
-| ------------- | --------- | ----------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | 数据库类型：`sqlite`、`mysql`、`postgres` |
-| `DB_HOST`     | —         | 数据库主机（mysql/postgres 必填）         |
-| `DB_PORT`     | —         | 数据库端口（mysql/postgres 必填）         |
-| `DB_USER`     | —         | 数据库用户名（mysql/postgres 必填）       |
-| `DB_PASSWORD` | —         | 数据库密码（mysql/postgres 必填）         |
-| `DB_NAME`     | —         | 数据库名称（mysql/postgres 必填）         |
-| `DB_SSL_MODE` | `disable` | Postgres SSL 模式                         |
+| 变量          | 默认值    | 说明                                                 |
+| ------------- | --------- | ---------------------------------------------------- |
+| `DB_TYPE`     | `sqlite`  | 数据库类型：`sqlite`、`mysql`、`postgres`、`mariadb` |
+| `DB_HOST`     | —         | 数据库主机（mysql/postgres 必填）                    |
+| `DB_PORT`     | —         | 数据库端口（mysql/postgres 必填）                    |
+| `DB_USER`     | —         | 数据库用户名（mysql/postgres 必填）                  |
+| `DB_PASSWORD` | —         | 数据库密码（mysql/postgres 必填）                    |
+| `DB_NAME`     | —         | 数据库名称（mysql/postgres 必填）                    |
+| `DB_SSL_MODE` | `disable` | Postgres SSL 模式                                    |
 
 #### SSO / 单点登录
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	BaseURL string `mapstructure:"base_url"`
 
 	// Database configuration
-	DBType     string `mapstructure:"db_type"`     // Database type: "sqlite", "mysql", or "postgres"
+	DBType     string `mapstructure:"db_type"`     // Database type: "sqlite", "mysql", "mariadb", or "postgres"
 	DBHost     string `mapstructure:"db_host"`     // Database host
 	DBPort     int    `mapstructure:"db_port"`     // Database port
 	DBUser     string `mapstructure:"db_user"`     // Database user

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -30,8 +30,8 @@ func Open(cfg *config.Config, dataDir string) (*gorm.DB, error) {
 	}
 
 	switch dbType {
-	case "mysql":
-		// MySQL connection - use config values with environment fallback
+	case "mysql", "mariadb":
+		// MySQL/MariaDB connection - use config values with environment fallback
 		return openMySQL(cfg)
 	case "postgres":
 		// PostgreSQL connection - use config values with environment fallback

--- a/backend/internal/database/database_test.go
+++ b/backend/internal/database/database_test.go
@@ -1,8 +1,11 @@
 package database
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vexgo-org/vexgo/backend/internal/config"
@@ -243,5 +246,101 @@ func TestSeed_PreservesExistingAdmin(t *testing.T) {
 	}
 	if admin.Email != "custom-admin@example.com" {
 		t.Errorf("expected existing admin email preserved, got %q", admin.Email)
+	}
+}
+
+// freePort returns an unused TCP port on loopback. The MySQL driver is eager
+// (gorm.Open dials the server immediately), so pointing it at a free, unbound
+// port yields a deterministic connection-refused error with no live database.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// TestOpenMariaDBRoutesToMySQL verifies that the "mariadb" DB type is treated
+// identically to "mysql": it must take the MySQL connection path (not fall
+// through to SQLite or PostgreSQL) and use the configured host/port.
+func TestOpenMariaDBRoutesToMySQL(t *testing.T) {
+	port := freePort(t)
+	cfg := &config.Config{
+		DBType:     "mariadb",
+		DBUser:     "vexgo",
+		DBHost:     "127.0.0.1",
+		DBPort:     port,
+		DBName:     "vexgo",
+		DBPassword: "secret",
+	}
+
+	db, err := Open(cfg, "")
+	if db != nil {
+		t.Fatalf("expected no DB handle for unreachable MariaDB, got %v", db)
+	}
+	if err == nil {
+		t.Fatal("expected connection error for unreachable MariaDB, got nil")
+	}
+	// The error must originate from the MySQL connection path, proving
+	// "mariadb" routes to openMySQL rather than SQLite/PostgreSQL.
+	if !strings.Contains(err.Error(), "MySQL") {
+		t.Fatalf("expected MySQL connection error, got: %v", err)
+	}
+	// And it must have attempted the configured host/port (config-driven DSN).
+	if !strings.Contains(err.Error(), fmt.Sprintf("127.0.0.1:%d", port)) {
+		t.Fatalf("expected connection attempt at configured host/port, got: %v", err)
+	}
+}
+
+// TestOpenMariaDBViaEnv verifies the "mariadb" type resolves from the
+// DB_TYPE environment variable and uses the DB_PORT env fallback.
+func TestOpenMariaDBViaEnv(t *testing.T) {
+	t.Setenv("DB_TYPE", "mariadb")
+	port := freePort(t)
+	t.Setenv("DB_PORT", fmt.Sprintf("%d", port))
+
+	cfg := &config.Config{
+		DBType: "", // force fallback to environment variable
+		DBHost: "127.0.0.1",
+		DBName: "vexgo",
+		DBUser: "vexgo",
+	}
+
+	db, err := Open(cfg, "")
+	if db != nil {
+		t.Fatalf("expected no DB handle, got %v", db)
+	}
+	if err == nil {
+		t.Fatal("expected connection error, got nil")
+	}
+	if !strings.Contains(err.Error(), "MySQL") {
+		t.Fatalf("expected MariaDB (via env) to route to MySQL path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("127.0.0.1:%d", port)) {
+		t.Fatalf("expected DB_PORT env fallback to be used, got: %v", err)
+	}
+}
+
+// TestOpenMySQLStillRoutesToMySQL guards against regressions: the explicit
+// "mysql" type must continue to take the MySQL path.
+func TestOpenMySQLStillRoutesToMySQL(t *testing.T) {
+	port := freePort(t)
+	cfg := &config.Config{
+		DBType: "mysql",
+		DBHost: "127.0.0.1",
+		DBPort: port,
+		DBName: "vexgo",
+		DBUser: "vexgo",
+	}
+
+	db, err := Open(cfg, "")
+	if db != nil {
+		t.Fatalf("expected no DB handle, got %v", db)
+	}
+	if err == nil || !strings.Contains(err.Error(), "MySQL") {
+		t.Fatalf("expected MySQL routing, got err=%v", err)
 	}
 }

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -51,7 +51,7 @@ behind_reverse_proxy: false
 trusted_proxies: []
 
 # Database
-db_type: "sqlite" # sqlite | mysql | postgres
+db_type: "sqlite" # sqlite | mysql | postgres | mariadb
 
 # SSO
 github_client_id: ""
@@ -87,7 +87,7 @@ Every setting can also be provided as an environment variable. This is the natur
 
 | Variable      | Default   | Description                                                         |
 | ------------- | --------- | ------------------------------------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | `sqlite`, `mysql`, or `postgres`                                    |
+| `DB_TYPE`     | `sqlite`  | `sqlite`, `mysql`, `postgres`, or `mariadb`                         |
 | `DB_HOST`     | —         | Host (required for mysql/postgres)                                  |
 | `DB_PORT`     | —         | Port (required for mysql/postgres)                                  |
 | `DB_USER`     | —         | Username (required for mysql/postgres)                              |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,7 +49,7 @@ Run `./vexgo --help` for the authoritative list.
 
 | Variable      | Default   | Description                                                         |
 | ------------- | --------- | ------------------------------------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | Database type: `sqlite`, `mysql`, or `postgres`                     |
+| `DB_TYPE`     | `sqlite`  | Database type: `sqlite`, `mysql`, `postgres`, or `mariadb`          |
 | `DB_HOST`     | —         | Database host (required for mysql/postgres)                         |
 | `DB_PORT`     | —         | Database port (required for mysql/postgres)                         |
 | `DB_USER`     | —         | Database username (required for mysql/postgres)                     |
@@ -135,7 +135,7 @@ The config file uses the same settings with lowercase YAML keys. The canonical e
 
 | YAML key      | Default   | Description                                 |
 | ------------- | --------- | ------------------------------------------- |
-| `db_type`     | `sqlite`  | `sqlite`, `mysql`, or `postgres`            |
+| `db_type`     | `sqlite`  | `sqlite`, `mysql`, `postgres`, or `mariadb` |
 | `db_host`     | —         | Host (required for mysql/postgres)          |
 | `db_port`     | —         | Port (required for mysql/postgres)          |
 | `db_user`     | —         | Username (required for mysql/postgres)      |

--- a/docs/zh-cn/guides/configuration.md
+++ b/docs/zh-cn/guides/configuration.md
@@ -51,7 +51,7 @@ behind_reverse_proxy: false
 trusted_proxies: []
 
 # 数据库
-db_type: "sqlite" # sqlite | mysql | postgres
+db_type: "sqlite" # sqlite | mysql | postgres | mariadb
 
 # SSO
 github_client_id: ""
@@ -87,7 +87,7 @@ s3_bucket: "my-bucket"
 
 | 变量          | 默认值    | 说明                                                                |
 | ------------- | --------- | ------------------------------------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | `sqlite`、`mysql` 或 `postgres`                                     |
+| `DB_TYPE`     | `sqlite`  | `sqlite`、`mysql`、`postgres` 或 `mariadb`                          |
 | `DB_HOST`     | —         | 主机（mysql/postgres 必填）                                         |
 | `DB_PORT`     | —         | 端口（mysql/postgres 必填）                                         |
 | `DB_USER`     | —         | 用户名（mysql/postgres 必填）                                       |

--- a/docs/zh-cn/reference/configuration.md
+++ b/docs/zh-cn/reference/configuration.md
@@ -49,7 +49,7 @@
 
 | 变量          | 默认值    | 说明                                                                |
 | ------------- | --------- | ------------------------------------------------------------------- |
-| `DB_TYPE`     | `sqlite`  | 数据库类型：`sqlite`、`mysql` 或 `postgres`                         |
+| `DB_TYPE`     | `sqlite`  | 数据库类型：`sqlite`、`mysql`、`postgres` 或 `mariadb`              |
 | `DB_HOST`     | —         | 数据库主机（mysql/postgres 必填）                                   |
 | `DB_PORT`     | —         | 数据库端口（mysql/postgres 必填）                                   |
 | `DB_USER`     | —         | 数据库用户名（mysql/postgres 必填）                                 |
@@ -133,15 +133,15 @@
 
 ### 数据库
 
-| YAML 键       | 默认值    | 说明                            |
-| ------------- | --------- | ------------------------------- |
-| `db_type`     | `sqlite`  | `sqlite`、`mysql` 或 `postgres` |
-| `db_host`     | —         | 主机（mysql/postgres 必填）     |
-| `db_port`     | —         | 端口（mysql/postgres 必填）     |
-| `db_user`     | —         | 用户名（mysql/postgres 必填）   |
-| `db_password` | —         | 密码（mysql/postgres 必填）     |
-| `db_name`     | —         | 数据库名（mysql/postgres 必填） |
-| `db_ssl_mode` | `disable` | Postgres SSL 模式               |
+| YAML 键       | 默认值    | 说明                                       |
+| ------------- | --------- | ------------------------------------------ |
+| `db_type`     | `sqlite`  | `sqlite`、`mysql`、`postgres` 或 `mariadb` |
+| `db_host`     | —         | 主机（mysql/postgres 必填）                |
+| `db_port`     | —         | 端口（mysql/postgres 必填）                |
+| `db_user`     | —         | 用户名（mysql/postgres 必填）              |
+| `db_password` | —         | 密码（mysql/postgres 必填）                |
+| `db_name`     | —         | 数据库名（mysql/postgres 必填）            |
+| `db_ssl_mode` | `disable` | Postgres SSL 模式                          |
 
 ### SSO
 

--- a/examples/config-mysql.yml
+++ b/examples/config-mysql.yml
@@ -46,10 +46,10 @@ trusted_proxies: []
 # ==================== Database Configuration ====================
 
 # Database type
-# Options: "sqlite", "mysql", "postgres"
+# Options: "sqlite", "mysql", "postgres", "mariadb"
 db_type: "mysql"
 
-# When db_type is "mysql", configure the following parameters
+# When db_type is "mysql" or "mariadb", configure the following parameters
 db_host: "127.0.0.1"
 db_port: 3306
 db_user: "vexgo_user"

--- a/examples/config-postgres.yml
+++ b/examples/config-postgres.yml
@@ -46,7 +46,7 @@ trusted_proxies: []
 # ==================== Database Configuration ====================
 
 # Database type
-# Options: "sqlite", "mysql", "postgres"
+# Options: "sqlite", "mysql", "postgres", "mariadb"
 db_type: "postgres"
 
 # PostgreSQL specific configuration

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -46,10 +46,10 @@ trusted_proxies: []
 # ==================== Database Configuration ====================
 
 # Database type
-# Options: "sqlite", "mysql", "postgres"
+# Options: "sqlite", "mysql", "postgres", "mariadb"
 db_type: "sqlite"
 
-# When db_type is "mysql", configure the following parameters
+# When db_type is "mysql" or "mariadb", configure the following parameters
 # db_host: "127.0.0.1"
 # db_port: 3306
 # db_user: "your_username"


### PR DESCRIPTION
## Description

This PR implemented #12.

## Changes

- **feat(database): support MariaDB**
- **test: add test cases for MariaDB configuration**
- **docs: add `mariadb` option to database configuration**
