### PR TITLE
fix(security): Security hardening: backend audit fixes

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -145,6 +145,7 @@ func New(cfg *config.Config) (*App, error) {
 			DB:        db,
 			SSO:       &cfg.SSO,
 			JWTSecret: cfg.JWTSecret,
+			Mailer:    mailerSvc,
 			BaseURL:   cfg.BaseURL,
 		},
 		Home: home.Deps{

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -136,6 +136,7 @@ func New(cfg *config.Config) (*App, error) {
 			Captcha:            captchaSvc,
 			BaseURL:            cfg.BaseURL,
 			BehindReverseProxy: cfg.BehindReverseProxy,
+			RateLimitPerMinute: cfg.AuthRateLimitPerMinute,
 		},
 		SSO: sso.Deps{
 			DB:        db,

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -5,7 +5,9 @@ package app
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/vexgo-org/vexgo/backend/internal/auth"
 	"github.com/vexgo-org/vexgo/backend/internal/captcha"
@@ -81,6 +83,7 @@ func New(cfg *config.Config) (*App, error) {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestLogger())
+	r.Use(middleware.SecurityHeaders())
 
 	renderer := public.NewRenderer(db, fmt.Sprintf("http://%s", cfg.GetListenAddr()), cfg.DataDir)
 	slog.Info("base url set for server-side rendering", "baseURL", renderer.BaseURL())
@@ -162,10 +165,21 @@ func New(cfg *config.Config) (*App, error) {
 	return &App{cfg: cfg, db: db, engine: r}, nil
 }
 
-// Run starts the HTTP server.
+// Run starts the HTTP server. Explicit timeouts guard against slow-loris and
+// slow-body connection exhaustion, which the net/http defaults (no timeouts)
+// do not protect against.
 func (a *App) Run() error {
+	srv := &http.Server{
+		Addr:              a.cfg.GetListenAddr(),
+		Handler:           a.engine,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
 	slog.Info("starting server", "address", a.cfg.GetListenAddr())
-	return a.engine.Run(a.cfg.GetListenAddr())
+	return srv.ListenAndServe()
 }
 
 // initStorage returns the file storage backend: local disk by default, or an

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -28,6 +28,10 @@ type Handler struct {
 	// proxy. Gin's trusted-proxies check filters the client IP but does not
 	// sanitize raw header reads, so this gate lives at the read site.
 	honorForwardedProto bool
+
+	// rateLimitPerMinute caps unauthenticated credential endpoints per client
+	// IP; mirrored from deps.RateLimitPerMinute.
+	rateLimitPerMinute int
 }
 
 // NewHandler creates an auth HTTP handler with the given dependencies.
@@ -39,6 +43,7 @@ func NewHandler(deps Deps) *Handler {
 		linkScheme:          scheme,
 		linkHost:            host,
 		honorForwardedProto: deps.BehindReverseProxy,
+		rateLimitPerMinute:  deps.RateLimitPerMinute,
 	}
 }
 

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -291,7 +291,7 @@ func (errRepo) GetGeneralSettings(context.Context) (model.GeneralSettings, error
 func (errRepo) FindCaptcha(context.Context, string, string) (*model.Captcha, error) {
 	return nil, gorm.ErrRecordNotFound
 }
-func (errRepo) MarkCaptchaUsed(context.Context, string, string) error { return nil }
+func (errRepo) DeleteCaptcha(context.Context, string, string) error { return nil }
 func (errRepo) UpdateEmailChangeToken(context.Context, uint, string, string, time.Time) error {
 	return nil
 }

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -288,6 +288,10 @@ func (errRepo) GetGeneralSettings(context.Context) (model.GeneralSettings, error
 	return model.GeneralSettings{}, nil
 }
 
+func (errRepo) FindMediaByURL(context.Context, string) (*model.MediaFile, error) {
+	return nil, gorm.ErrRecordNotFound
+}
+
 func (errRepo) FindCaptcha(context.Context, string, string) (*model.Captcha, error) {
 	return nil, gorm.ErrRecordNotFound
 }

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -26,10 +26,9 @@ type Repository interface {
 	ResetPassword(ctx context.Context, userID uint, hashedPassword string) error
 	GetGeneralSettings(ctx context.Context) (model.GeneralSettings, error)
 	FindCaptcha(ctx context.Context, id, token string) (*model.Captcha, error)
-	// MarkCaptchaUsed atomically flips used=false to true for the given
-	// challenge; the result is ignored because an already-used captcha is
-	// accepted idempotently at submit time.
-	MarkCaptchaUsed(ctx context.Context, id, token string) error
+	// DeleteCaptcha removes a consumed or rejected challenge so the same
+	// (id, token, x, y) answer cannot be replayed against auth endpoints.
+	DeleteCaptcha(ctx context.Context, id, token string) error
 	UpdateEmailChangeToken(ctx context.Context, userID uint, newEmail, token string, expiresAt time.Time) error
 }
 
@@ -123,7 +122,11 @@ func (r *gormRepository) UpdateUserEmailVerified(ctx context.Context, userID uin
 func (r *gormRepository) ResetPassword(ctx context.Context, userID uint, hashedPassword string) error {
 	return r.db.WithContext(ctx).Model(&model.User{}).Where("id = ?", userID).
 		Updates(map[string]any{
-			"password":           hashedPassword,
+			"password": hashedPassword,
+			// Bumping the version invalidates every outstanding JWT issued
+			// before the reset (enforced by middleware.auth), so a stolen
+			// session cannot survive a password reset.
+			"password_version":   gorm.Expr("password_version + 1"),
 			"verification_token": "",
 			"token_expires_at":   time.Time{},
 		}).Error
@@ -145,10 +148,10 @@ func (r *gormRepository) FindCaptcha(ctx context.Context, id, token string) (*mo
 	return &captcha, nil
 }
 
-func (r *gormRepository) MarkCaptchaUsed(ctx context.Context, id, token string) error {
-	return r.db.WithContext(ctx).Model(&model.Captcha{}).
-		Where("id = ? AND token = ? AND used = ?", id, token, false).
-		Update("used", true).Error
+func (r *gormRepository) DeleteCaptcha(ctx context.Context, id, token string) error {
+	return r.db.WithContext(ctx).
+		Where("id = ? AND token = ?", id, token).
+		Delete(&model.Captcha{}).Error
 }
 
 func (r *gormRepository) UpdateUserToken(ctx context.Context, userID uint, token string, expiresAt time.Time) error {

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -25,6 +25,9 @@ type Repository interface {
 	UpdateUserEmailVerified(ctx context.Context, userID uint) error
 	ResetPassword(ctx context.Context, userID uint, hashedPassword string) error
 	GetGeneralSettings(ctx context.Context) (model.GeneralSettings, error)
+	// FindMediaByURL looks up the media_files row behind a stored URL so
+	// avatar cleanup can verify ownership before deleting the file.
+	FindMediaByURL(ctx context.Context, url string) (*model.MediaFile, error)
 	FindCaptcha(ctx context.Context, id, token string) (*model.Captcha, error)
 	// DeleteCaptcha removes a consumed or rejected challenge so the same
 	// (id, token, x, y) answer cannot be replayed against auth endpoints.
@@ -138,6 +141,14 @@ func (r *gormRepository) GetGeneralSettings(ctx context.Context) (model.GeneralS
 		return settings, err
 	}
 	return settings, nil
+}
+
+func (r *gormRepository) FindMediaByURL(ctx context.Context, url string) (*model.MediaFile, error) {
+	var media model.MediaFile
+	if err := r.db.WithContext(ctx).Where("url = ?", url).First(&media).Error; err != nil {
+		return nil, err
+	}
+	return &media, nil
 }
 
 func (r *gormRepository) FindCaptcha(ctx context.Context, id, token string) (*model.Captcha, error) {

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -74,6 +74,13 @@ func (r *gormRepository) FindUserByEmailExcluding(
 }
 
 func (r *gormRepository) FindUserByToken(ctx context.Context, token string) (*model.User, error) {
+	if token == "" {
+		// An empty lookup must never resolve: cleared tokens are stored as
+		// the empty sentinel, so a missing/empty parameter would otherwise
+		// match whichever account last cleared its token. (The hashing below
+		// already fails to match it; this guard is the explicit contract.)
+		return nil, gorm.ErrRecordNotFound
+	}
 	var user model.User
 	// Tokens are stored hashed (tokenStorageForm); the presented raw token is
 	// hashed the same way before the lookup, so the plaintext never exists in

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -75,7 +75,10 @@ func (r *gormRepository) FindUserByEmailExcluding(
 
 func (r *gormRepository) FindUserByToken(ctx context.Context, token string) (*model.User, error) {
 	var user model.User
-	if err := r.db.WithContext(ctx).Where("verification_token = ?", token).First(&user).Error; err != nil {
+	// Tokens are stored hashed (tokenStorageForm); the presented raw token is
+	// hashed the same way before the lookup, so the plaintext never exists in
+	// the database.
+	if err := r.db.WithContext(ctx).Where("verification_token = ?", tokenStorageForm(token)).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil

--- a/backend/internal/auth/routes.go
+++ b/backend/internal/auth/routes.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"github.com/vexgo-org/vexgo/backend/internal/middleware"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -10,17 +12,31 @@ import (
 func (h *Handler) RegisterRoutes(api *gin.RouterGroup) {
 	auth := api.Group("/auth")
 	{
-		auth.POST("/register", h.Register)
-		auth.POST("/login", h.Login)
+		// Unauthenticated credential endpoints carry a per-IP rate limit so
+		// online brute-force and mail-bombing cannot run unchecked even when
+		// captcha is disabled.
+		limited := middleware.NewRateLimiter(h.rateLimitPerMinute)
+
+		if limited != nil {
+			auth.POST("/register", limited, h.Register)
+			auth.POST("/login", limited, h.Login)
+			auth.POST("/request-password-reset", limited, h.RequestPasswordReset)
+			auth.POST("/resend-verification", limited, h.ResendVerification)
+			auth.POST("/reset-password", limited, h.ResetPassword)
+		} else {
+			auth.POST("/register", h.Register)
+			auth.POST("/login", h.Login)
+			auth.POST("/request-password-reset", h.RequestPasswordReset)
+			auth.POST("/resend-verification", h.ResendVerification)
+			auth.POST("/reset-password", h.ResetPassword)
+		}
+
 		auth.GET("/me", h.mw.JWTAuth(), h.GetCurrentUser)
 		auth.GET("/user", h.mw.JWTAuth(), h.GetCurrentUser)
 		auth.PUT("/profile", h.mw.JWTAuth(), h.UpdateProfile)
 		auth.PUT("/password", h.mw.JWTAuth(), h.ChangePassword)
 		auth.PUT("/email", h.mw.JWTAuth(), h.UpdateEmail)
 		auth.PUT("/settings", h.mw.JWTAuth(), h.UpdateSettings)
-		auth.POST("/request-password-reset", h.RequestPasswordReset)
-		auth.POST("/resend-verification", h.ResendVerification)
-		auth.POST("/reset-password", h.ResetPassword)
 		auth.GET("/verification-status", h.mw.JWTAuth(), h.GetVerificationStatus)
 	}
 

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -98,6 +100,10 @@ type Deps struct {
 	// BehindReverseProxy enables honoring X-Forwarded-Proto when BaseURL is
 	// not configured. Mirrors cfg.BehindReverseProxy / behind_reverse_proxy.
 	BehindReverseProxy bool
+	// RateLimitPerMinute caps unauthenticated auth requests (register, login,
+	// password reset, verification resend) per client IP per minute; 0 or less
+	// disables the limiter.
+	RateLimitPerMinute int
 }
 
 // FileRemover is an alias for model.FileRemover kept for backward compatibility.
@@ -763,7 +769,7 @@ func (s *Service) verifyCaptcha(ctx context.Context, arg *verifyCaptchaArgs) err
 			"tolerance", arg.Tolerance,
 			"email", arg.Email,
 		)
-		if err := s.repo.MarkCaptchaUsed(ctx, arg.ID, arg.Token); err != nil {
+		if err := s.repo.DeleteCaptcha(ctx, arg.ID, arg.Token); err != nil {
 			slog.Error(
 				"failed to invalidate captcha after mismatch",
 				"captchaID", arg.ID,
@@ -781,30 +787,46 @@ func (s *Service) verifyCaptcha(ctx context.Context, arg *verifyCaptchaArgs) err
 		"email", arg.Email,
 	)
 
-	// If captcha has not been used yet, mark it as used. The conditional
-	// update makes the claim atomic; an already-used captcha passes either
-	// way because the drop-time pre-verification marked it.
-	if !captcha.Used {
-		if err := s.repo.MarkCaptchaUsed(ctx, arg.ID, arg.Token); err != nil {
-			slog.Error(
-				"failed to mark captcha as used",
-				"captchaID", arg.ID,
-				"email", arg.Email,
-				"err", err,
-			)
-			return ErrCaptchaFailed
-		}
-		slog.Debug("captcha marked as used", "captchaID", arg.ID)
+	// Consume the challenge here, at the sensitive action it protects: the
+	// drop-time pre-verification (POST /api/captcha/verify) only marks it
+	// used, so without this deletion the same (id, token, x, y) answer could
+	// be replayed against login/register until the challenge expires.
+	if err := s.repo.DeleteCaptcha(ctx, arg.ID, arg.Token); err != nil {
+		slog.Error(
+			"failed to consume captcha after successful verification",
+			"captchaID", arg.ID,
+			"email", arg.Email,
+			"err", err,
+		)
+		return ErrCaptchaFailed
 	}
-	// If captcha already used, pre-verification successful, pass directly
 
 	return nil
 }
 
+// secureTokenEntropy is the number of random bytes in every emailed account
+// token (reset, verification, email change): 32 bytes give 256 bits, far above
+// the 128-bit floor for unguessable one-time tokens.
+const secureTokenEntropy = 32
+
+// generateSecureToken returns prefix + 256 bits of crypto/rand entropy encoded
+// as unpadded base64url. The token is stored and looked up as-is (plaintext
+// column equality); the entropy — not the format — is what makes it
+// unguessable within its 5-minute window.
+func generateSecureToken(prefix string) (string, error) {
+	b := make([]byte, secureTokenEntropy)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
 // GeneratePasswordResetToken generates password reset token
 func (s *Service) GeneratePasswordResetToken(ctx context.Context, userID uint) (string, error) {
-	// Generate random token
-	token := model.TokenPrefixReset + fmt.Sprintf("%d-%d", userID, time.Now().UnixNano())
+	token, err := generateSecureToken(model.TokenPrefixReset)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate password reset token: %w", err)
+	}
 
 	// Calculate expiration time (5 minutes from now)
 	expiresAt := time.Now().Add(5 * time.Minute)
@@ -819,8 +841,10 @@ func (s *Service) GeneratePasswordResetToken(ctx context.Context, userID uint) (
 
 // GenerateEmailChangeToken generates email change verification token
 func (s *Service) GenerateEmailChangeToken(ctx context.Context, userID uint, newEmail string) (string, error) {
-	// Generate random token
-	token := model.TokenPrefixEmailChange + fmt.Sprintf("%d-%d", userID, time.Now().UnixNano())
+	token, err := generateSecureToken(model.TokenPrefixEmailChange)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate email change token: %w", err)
+	}
 
 	// Calculate expiration time (5 minutes from now)
 	expiresAt := time.Now().Add(5 * time.Minute)
@@ -834,8 +858,10 @@ func (s *Service) GenerateEmailChangeToken(ctx context.Context, userID uint, new
 }
 
 func (s *Service) GenerateVerificationToken(ctx context.Context, userID uint) (string, error) {
-	// Generate random token (should use more secure method in production)
-	token := model.TokenPrefixVerify + fmt.Sprintf("%d-%d", userID, time.Now().UnixNano())
+	token, err := generateSecureToken(model.TokenPrefixVerify)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate verification token: %w", err)
+	}
 
 	// Calculate expiration time (5 minutes from now)
 	expiresAt := time.Now().Add(5 * time.Minute)

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -455,17 +455,14 @@ func (s *Service) UpdateProfile(ctx context.Context, userID uint, req UpdateProf
 		return nil, err
 	}
 
-	// If updating avatar, delete old avatar
+	// If updating avatar, delete the old avatar file — but only when it maps
+	// to a media record owned by this user. The stored URL is
+	// client-controlled (set by a previous profile update), and
+	// Storage.Delete resolves it back to a storage key (for S3, any key in
+	// the bucket), so deleting on faith would let a user wipe arbitrary
+	// objects by first pointing their avatar at them.
 	if req.Avatar != nil && *req.Avatar != user.Avatar && user.Avatar != "" {
-		// Delete old avatar file
-		if err := s.files.Delete(user.Avatar); err != nil {
-			// Log error but continue execution to avoid avatar update failure
-			slog.Warn(
-				"failed to delete old avatar",
-				"url", user.Avatar,
-				"err", err,
-			)
-		}
+		s.deleteOldAvatar(ctx, userID, user.Avatar)
 		user.Avatar = *req.Avatar
 	} else if req.Avatar != nil {
 		user.Avatar = *req.Avatar
@@ -484,6 +481,30 @@ func (s *Service) UpdateProfile(ctx context.Context, userID uint, req UpdateProf
 		return nil, err
 	}
 	return user, nil
+}
+
+// deleteOldAvatar removes the file behind a replaced avatar when — and only
+// when — it is a media file owned by the acting user. Anything else
+// (external URLs, records that no longer exist, other users' files, DB
+// errors) is logged and skipped: the cleanup is best-effort and must never
+// widen into deleting unmanaged or third-party storage objects.
+func (s *Service) deleteOldAvatar(ctx context.Context, userID uint, url string) {
+	media, err := s.repo.FindMediaByURL(ctx, url)
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		slog.Warn("old avatar has no media record, skipping deletion", "userID", userID, "url", url)
+		return
+	case err != nil:
+		slog.Warn("failed to look up old avatar media record, skipping deletion", "userID", userID, "url", url, "err", err)
+		return
+	}
+	if media.UserID != userID {
+		slog.Warn("old avatar media record belongs to another user, skipping deletion", "userID", userID, "ownerID", media.UserID, "url", url)
+		return
+	}
+	if err := s.files.Delete(url); err != nil {
+		slog.Warn("failed to delete old avatar", "url", url, "err", err)
+	}
 }
 
 // ChangePassword verifies the old password and replaces it with the new one,

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -831,15 +833,38 @@ func (s *Service) verifyCaptcha(ctx context.Context, arg *verifyCaptchaArgs) err
 const secureTokenEntropy = 32
 
 // generateSecureToken returns prefix + 256 bits of crypto/rand entropy encoded
-// as unpadded base64url. The token is stored and looked up as-is (plaintext
-// column equality); the entropy — not the format — is what makes it
-// unguessable within its 5-minute window.
+// as unpadded base64url. The token is emailed in this raw form; only its
+// storage form (see tokenStorageForm) is persisted.
 func generateSecureToken(prefix string) (string, error) {
 	b := make([]byte, secureTokenEntropy)
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
 	return prefix + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// tokenStorageForm maps a raw emailed token to its at-rest representation:
+// the kind prefix followed by the SHA-256 of the rest. Only this form is
+// persisted, so a database leak does not expose live one-time tokens, and
+// lookups compare hashes instead of plaintext. The prefix is preserved so the
+// token-kind checks on stored values (e.g. the verification-resend cooldown)
+// keep working. Unknown tokens hash in full (empty prefix) and match nothing.
+func tokenStorageForm(rawToken string) string {
+	prefix := tokenKindPrefix(rawToken)
+	sum := sha256.Sum256([]byte(rawToken[len(prefix):]))
+	return prefix + hex.EncodeToString(sum[:])
+}
+
+// tokenKindPrefix returns the known account-token prefix of a raw token, or
+// "" for unrecognized input. Prefixes are matched longest-first because
+// TokenPrefixEmailChange contains an inner hyphen.
+func tokenKindPrefix(rawToken string) string {
+	for _, prefix := range []string{model.TokenPrefixEmailChange, model.TokenPrefixReset, model.TokenPrefixVerify} {
+		if strings.HasPrefix(rawToken, prefix) {
+			return prefix
+		}
+	}
+	return ""
 }
 
 // GeneratePasswordResetToken generates password reset token
@@ -853,7 +878,7 @@ func (s *Service) GeneratePasswordResetToken(ctx context.Context, userID uint) (
 	expiresAt := time.Now().Add(5 * time.Minute)
 
 	// Save to database
-	if err := s.repo.UpdateUserToken(ctx, userID, token, expiresAt); err != nil {
+	if err := s.repo.UpdateUserToken(ctx, userID, tokenStorageForm(token), expiresAt); err != nil {
 		return "", fmt.Errorf("failed to save password reset token: %w", err)
 	}
 
@@ -871,7 +896,7 @@ func (s *Service) GenerateEmailChangeToken(ctx context.Context, userID uint, new
 	expiresAt := time.Now().Add(5 * time.Minute)
 
 	// Save to database, also store pending new email
-	if err := s.repo.UpdateEmailChangeToken(ctx, userID, newEmail, token, expiresAt); err != nil {
+	if err := s.repo.UpdateEmailChangeToken(ctx, userID, newEmail, tokenStorageForm(token), expiresAt); err != nil {
 		return "", fmt.Errorf("failed to update email change token: %w", err)
 	}
 
@@ -888,7 +913,7 @@ func (s *Service) GenerateVerificationToken(ctx context.Context, userID uint) (s
 	expiresAt := time.Now().Add(5 * time.Minute)
 
 	// Save to database
-	if err := s.repo.UpdateUserToken(ctx, userID, token, expiresAt); err != nil {
+	if err := s.repo.UpdateUserToken(ctx, userID, tokenStorageForm(token), expiresAt); err != nil {
 		return "", fmt.Errorf("failed to save verification token: %w", err)
 	}
 

--- a/backend/internal/auth/service_email.go
+++ b/backend/internal/auth/service_email.go
@@ -47,7 +47,9 @@ func (s *Service) VerifyEmail(ctx context.Context, token string) (emailChange bo
 
 // ConfirmEmailChange confirms email change
 func (s *Service) ConfirmEmailChange(ctx context.Context, token string) error {
-	slog.Debug("confirm email change processing started", "token", token)
+	// security: the token value must stay out of the logs — it is a live
+	// account-takeover credential until consumed.
+	slog.Debug("confirm email change processing started")
 
 	// Only email-change tokens may confirm an email change.
 	if !strings.HasPrefix(token, model.TokenPrefixEmailChange) {

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -63,7 +63,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to get sql.DB: %v", err)
 	}
 	sqlDB.SetMaxOpenConns(1)
-	if err := db.AutoMigrate(&model.User{}, &model.Captcha{}, &model.GeneralSettings{}, &model.SMTPConfig{}); err != nil {
+	if err := db.AutoMigrate(&model.User{}, &model.Captcha{}, &model.GeneralSettings{}, &model.SMTPConfig{}, &model.MediaFile{}); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}
 	return db
@@ -480,25 +480,77 @@ func TestUpdateSettings(t *testing.T) {
 	}
 }
 
-func TestUpdateProfile_DeletesOldAvatar(t *testing.T) {
-	svc, files, db := newTestService(t)
-	u := seedUser(t, db, "alice@example.com", "password123", model.RoleGuest, true)
-	u.Avatar = "/uploads/old-avatar.png"
-	if err := db.Save(&u).Error; err != nil {
-		t.Fatalf("failed to set avatar: %v", err)
+// seedMedia inserts a media_files row for the given owner and URL.
+func seedMedia(t *testing.T, db *gorm.DB, userID uint, url string) model.MediaFile {
+	t.Helper()
+	media := model.MediaFile{URL: url, UserID: userID, Type: "image/png"}
+	if err := db.Create(&media).Error; err != nil {
+		t.Fatalf("failed to seed media: %v", err)
 	}
+	return media
+}
 
-	newAvatar := "/uploads/new-avatar.png"
-	user, err := svc.UpdateProfile(context.Background(), u.ID, UpdateProfileRequest{Avatar: &newAvatar})
-	if err != nil {
-		t.Fatalf("UpdateProfile error: %v", err)
-	}
-	if user.Avatar != newAvatar {
-		t.Errorf("expected new avatar, got %s", user.Avatar)
-	}
-	if len(files.deleted) != 1 || files.deleted[0] != "/uploads/old-avatar.png" {
-		t.Errorf("expected old avatar deleted, got %v", files.deleted)
-	}
+func TestUpdateProfile_DeletesOldAvatar(t *testing.T) {
+	t.Run("owned media record is deleted", func(t *testing.T) {
+		svc, files, db := newTestService(t)
+		u := seedUser(t, db, "alice@example.com", "password123", model.RoleGuest, true)
+		u.Avatar = "/uploads/old-avatar.png"
+		if err := db.Save(&u).Error; err != nil {
+			t.Fatalf("failed to set avatar: %v", err)
+		}
+		seedMedia(t, db, u.ID, "/uploads/old-avatar.png")
+
+		newAvatar := "/uploads/new-avatar.png"
+		user, err := svc.UpdateProfile(context.Background(), u.ID, UpdateProfileRequest{Avatar: &newAvatar})
+		if err != nil {
+			t.Fatalf("UpdateProfile error: %v", err)
+		}
+		if user.Avatar != newAvatar {
+			t.Errorf("expected new avatar, got %s", user.Avatar)
+		}
+		if len(files.deleted) != 1 || files.deleted[0] != "/uploads/old-avatar.png" {
+			t.Errorf("expected old avatar deleted, got %v", files.deleted)
+		}
+	})
+
+	// security: the stored avatar URL is client-controlled; pointing it at
+	// someone else's media (or an arbitrary S3 URL) must never trigger a
+	// delete of that object when the avatar changes again.
+	t.Run("media owned by another user is not deleted", func(t *testing.T) {
+		svc, files, db := newTestService(t)
+		u := seedUser(t, db, "alice@example.com", "password123", model.RoleGuest, true)
+		other := seedUser(t, db, "bob@example.com", "password123", model.RoleGuest, true)
+		u.Avatar = "/uploads/victim.png"
+		if err := db.Save(&u).Error; err != nil {
+			t.Fatalf("failed to set avatar: %v", err)
+		}
+		seedMedia(t, db, other.ID, "/uploads/victim.png")
+
+		newAvatar := "/uploads/new-avatar.png"
+		if _, err := svc.UpdateProfile(context.Background(), u.ID, UpdateProfileRequest{Avatar: &newAvatar}); err != nil {
+			t.Fatalf("UpdateProfile error: %v", err)
+		}
+		if len(files.deleted) != 0 {
+			t.Errorf("expected no deletions, got %v", files.deleted)
+		}
+	})
+
+	t.Run("unknown URL is not deleted", func(t *testing.T) {
+		svc, files, db := newTestService(t)
+		u := seedUser(t, db, "alice@example.com", "password123", model.RoleGuest, true)
+		u.Avatar = "https://bucket.s3.amazonaws.com/anything/secret.png"
+		if err := db.Save(&u).Error; err != nil {
+			t.Fatalf("failed to set avatar: %v", err)
+		}
+
+		newAvatar := "/uploads/new-avatar.png"
+		if _, err := svc.UpdateProfile(context.Background(), u.ID, UpdateProfileRequest{Avatar: &newAvatar}); err != nil {
+			t.Fatalf("UpdateProfile error: %v", err)
+		}
+		if len(files.deleted) != 0 {
+			t.Errorf("expected no deletions, got %v", files.deleted)
+		}
+	})
 }
 
 func TestResetPassword(t *testing.T) {

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -21,6 +21,24 @@ import (
 
 var testJWTSecret = []byte("test-secret-for-auth-tests")
 
+// seedCaptcha inserts a ready-to-use captcha challenge for login/register tests.
+func seedCaptcha(t *testing.T, db *gorm.DB, id, token string, x, y int) model.Captcha {
+	t.Helper()
+	captcha := model.Captcha{ID: id, Token: token, X: x, Y: y, Width: 60, Height: 60, ExpiresAt: time.Now().Add(5 * time.Minute)}
+	if err := db.Create(&captcha).Error; err != nil {
+		t.Fatalf("failed to seed captcha: %v", err)
+	}
+	return captcha
+}
+
+// captchaGone reports whether the challenge has been consumed (deleted).
+func captchaGone(t *testing.T, db *gorm.DB, id string) bool {
+	t.Helper()
+	var count int64
+	db.Model(&model.Captcha{}).Where("id = ?", id).Count(&count)
+	return count == 0
+}
+
 // capturedEmails records emails captured by the mailer test seam.
 var capturedEmails []capturedEmail
 
@@ -214,45 +232,47 @@ func TestLogin_WithCaptcha(t *testing.T) {
 	}
 
 	// missing captcha y coordinate
-	captcha := model.Captcha{ID: "c1", Token: "t1", X: 100, Y: 50, Width: 60, Height: 60, ExpiresAt: time.Now().Add(5 * time.Minute)}
-	if err := db.Create(&captcha).Error; err != nil {
-		t.Fatalf("failed to seed captcha: %v", err)
-	}
+	captcha := seedCaptcha(t, db, "c1", "t1", 100, 50)
+
 	if _, _, err := svc.Login(context.Background(), loginReq("c1", "t1", 100, 0)); !errors.Is(err, ErrCaptchaRequired) {
 		t.Errorf("expected ErrCaptchaRequired for missing y, got %v", err)
 	}
 
-	// wrong x position
+	// wrong x position — the failed attempt consumes the challenge
 	if _, _, err := svc.Login(context.Background(), loginReq("c1", "t1", 10, 50)); !errors.Is(err, ErrCaptchaMismatch) {
 		t.Errorf("expected ErrCaptchaMismatch for wrong x, got %v", err)
 	}
-
-	// wrong y position
-	if _, _, err := svc.Login(context.Background(), loginReq("c1", "t1", 100, 20)); !errors.Is(err, ErrCaptchaMismatch) {
-		t.Errorf("expected ErrCaptchaMismatch for wrong y, got %v", err)
+	if !captchaGone(t, db, captcha.ID) {
+		t.Errorf("expected failed-attempt captcha to be invalidated")
 	}
 
-	// correct position passes
-	token, _, err := svc.Login(context.Background(), loginReq("c1", "t1", 100, 50))
+	// wrong y position (fresh challenge — the previous one was consumed)
+	c2 := seedCaptcha(t, db, "c1b", "t1b", 100, 50)
+	if _, _, err := svc.Login(context.Background(), loginReq("c1b", "t1b", 100, 20)); !errors.Is(err, ErrCaptchaMismatch) {
+		t.Errorf("expected ErrCaptchaMismatch for wrong y, got %v", err)
+	}
+	if !captchaGone(t, db, c2.ID) {
+		t.Errorf("expected failed-attempt captcha to be invalidated")
+	}
+
+	// correct position passes (fresh challenge)
+	seedCaptcha(t, db, "c1c", "t1c", 100, 50)
+	token, _, err := svc.Login(context.Background(), loginReq("c1c", "t1c", 100, 50))
 	if err != nil {
 		t.Fatalf("Login with captcha error: %v", err)
 	}
 	if token == "" {
 		t.Errorf("expected token")
 	}
-	// captcha marked used
-	var stored model.Captcha
-	if err := db.First(&stored, "id = ?", "c1").Error; err != nil {
-		t.Fatalf("failed to reload captcha: %v", err)
-	}
-	if !stored.Used {
-		t.Errorf("expected captcha marked as used")
+	// the challenge is consumed at the sensitive action, not merely marked used
+	if !captchaGone(t, db, "c1c") {
+		t.Errorf("expected consumed captcha to be deleted")
 	}
 
-	// The submit-time re-check is idempotent: an already-used captcha still
-	// passes here because the pre-verification on drop already marked it.
-	if _, _, err := svc.Login(context.Background(), loginReq("c1", "t1", 100, 50)); err != nil {
-		t.Errorf("expected idempotent re-check to pass for used captcha, got %v", err)
+	// security: replaying the same (id, token, x, y) answer must fail — the
+	// consumed challenge no longer exists.
+	if _, _, err := svc.Login(context.Background(), loginReq("c1c", "t1c", 100, 50)); !errors.Is(err, ErrCaptchaNotFound) {
+		t.Errorf("expected ErrCaptchaNotFound for replayed captcha, got %v", err)
 	}
 }
 
@@ -320,8 +340,13 @@ func TestRegister_WithCaptcha(t *testing.T) {
 		t.Errorf("expected ErrCaptchaMismatch for wrong y, got %v", err)
 	}
 
-	// correct position passes
-	result, err := svc.Register(context.Background(), registerReq("c2", "t2", 80, 40))
+	// correct position passes (fresh challenge — the failed attempt consumed c2)
+	seedCaptcha(t, db, "c2b", "t2b", 80, 40)
+	result, err := svc.Register(context.Background(), RegisterRequest{
+		Email: "new@example.com", Password: "password123", Username: "newbie",
+		CaptchaID: "c2b", CaptchaToken: "t2b", CaptchaX: 80, CaptchaY: 40,
+		Protocol: "http", Host: "localhost",
+	})
 	if err != nil {
 		t.Fatalf("Register with captcha error: %v", err)
 	}
@@ -514,7 +539,7 @@ func TestResetPassword(t *testing.T) {
 		t.Errorf("expected ErrResetTokenExpired, got %v", err)
 	}
 
-	// success: token cleared
+	// success: token cleared and password version bumped (invalidates sessions)
 	if err := svc.ResetPassword(context.Background(), "reset-token", "newpass123"); err != nil {
 		t.Fatalf("ResetPassword error: %v", err)
 	}
@@ -524,6 +549,48 @@ func TestResetPassword(t *testing.T) {
 	}
 	if stored.VerificationToken != "" {
 		t.Errorf("expected token cleared")
+	}
+	if stored.PasswordVersion != u.PasswordVersion+1 {
+		t.Errorf("expected password version bumped from %d to %d, got %d",
+			u.PasswordVersion, u.PasswordVersion+1, stored.PasswordVersion)
+	}
+}
+
+// TestGenerateTokens_CryptoRandomAndPrefixed ensures the emailed account
+// tokens (reset / verification / email change) carry high entropy instead of
+// the former predictable "userID-nanotime" format, and keep their prefixes so
+// token kinds stay distinguishable.
+func TestGenerateTokens_CryptoRandomAndPrefixed(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		prefix string
+		gen    func(ctx context.Context, userID uint) (string, error)
+	}{
+		{model.TokenPrefixReset, svc.GeneratePasswordResetToken},
+		{model.TokenPrefixVerify, svc.GenerateVerificationToken},
+	}
+
+	for _, tc := range cases {
+		t1, err := tc.gen(ctx, 1)
+		if err != nil {
+			t.Fatalf("generate token error: %v", err)
+		}
+		t2, err := tc.gen(ctx, 1)
+		if err != nil {
+			t.Fatalf("generate token error: %v", err)
+		}
+
+		if !strings.HasPrefix(t1, tc.prefix) {
+			t.Errorf("expected prefix %q, got %q", tc.prefix, t1)
+		}
+		if t1 == t2 {
+			t.Errorf("expected two tokens for the same user to differ")
+		}
+		if len(t1) < len(tc.prefix)+43 { // 43 = base64url length of 32 bytes
+			t.Errorf("expected >= 256 bits of entropy, token too short: %q (%d chars)", t1, len(t1))
+		}
 	}
 }
 

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -573,6 +573,14 @@ func TestResetPassword(t *testing.T) {
 		t.Errorf("expected ErrInvalidResetToken, got %v", err)
 	}
 
+	// empty token must not resolve to an account whose token was cleared
+	if err := svc.ResetPassword(context.Background(), "", "newpass123"); !errors.Is(err, ErrInvalidResetToken) {
+		t.Errorf("expected ErrInvalidResetToken for empty token, got %v", err)
+	}
+	if _, err := svc.repo.FindUserByToken(context.Background(), ""); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("expected ErrRecordNotFound for empty token lookup, got %v", err)
+	}
+
 	// expired token (with the correct reset- prefix, so it reaches the
 	// expiry check instead of being rejected by the prefix check)
 	expiredAt := time.Now().Add(-1 * time.Minute)

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
-	"net/url"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -561,7 +561,7 @@ func TestResetPassword(t *testing.T) {
 		Email:             "alice@example.com",
 		Password:          "hash",
 		Role:              model.RoleGuest,
-		VerificationToken: "reset-token",
+		VerificationToken: tokenStorageForm("reset-token"),
 		TokenExpiresAt:    &expiresAt,
 	}
 	if err := db.Create(&u).Error; err != nil {
@@ -581,7 +581,7 @@ func TestResetPassword(t *testing.T) {
 		Email:             "bob@example.com",
 		Password:          "hash",
 		Role:              model.RoleGuest,
-		VerificationToken: "reset-expired",
+		VerificationToken: tokenStorageForm("reset-expired"),
 		TokenExpiresAt:    &expiredAt,
 	}
 	if err := db.Create(&u2).Error; err != nil {
@@ -656,7 +656,7 @@ func TestResetPassword_RejectsNonResetTokens(t *testing.T) {
 		Email:             "alice@example.com",
 		Password:          "hash",
 		Role:              model.RoleGuest,
-		VerificationToken: "verify-abc",
+		VerificationToken: tokenStorageForm("verify-abc"),
 		TokenExpiresAt:    &expiresAt,
 	}
 	if err := db.Create(&u1).Error; err != nil {
@@ -672,7 +672,7 @@ func TestResetPassword_RejectsNonResetTokens(t *testing.T) {
 		Email:             "bob@example.com",
 		Password:          "hash",
 		Role:              model.RoleGuest,
-		VerificationToken: "email-change-abc",
+		VerificationToken: tokenStorageForm("email-change-abc"),
 		TokenExpiresAt:    &expiresAt,
 	}
 	if err := db.Create(&u2).Error; err != nil {
@@ -685,7 +685,7 @@ func TestResetPassword_RejectsNonResetTokens(t *testing.T) {
 	// The rejected tokens are left untouched (not consumed).
 	for _, token := range []string{"verify-abc", "email-change-abc"} {
 		var stored model.User
-		if err := db.Where("verification_token = ?", token).First(&stored).Error; err != nil {
+		if err := db.Where("verification_token = ?", tokenStorageForm(token)).First(&stored).Error; err != nil {
 			t.Fatalf("token %q unexpectedly cleared: %v", token, err)
 		}
 	}
@@ -732,17 +732,16 @@ func captureEmails(t *testing.T) {
 }
 
 // extractToken pulls the token query parameter out of an emailed link.
-func extractToken(t *testing.T, link string) string {
+// emailedToken extracts the raw link token from a captured email's HTML body.
+// Raw tokens exist only in the email; the database holds their storage form
+// (see tokenStorageForm).
+func emailedToken(t *testing.T, email capturedEmail) string {
 	t.Helper()
-	u, err := url.Parse(link)
-	if err != nil {
-		t.Fatalf("failed to parse link %q: %v", link, err)
+	m := regexp.MustCompile(`token=([A-Za-z0-9_-]+)`).FindStringSubmatch(email.HTMLBody)
+	if m == nil {
+		t.Fatal("no token link in email body")
 	}
-	tok := u.Query().Get("token")
-	if tok == "" {
-		t.Fatalf("no token in link %q", link)
-	}
-	return tok
+	return m[1]
 }
 
 func TestRegister_SendsVerificationEmail(t *testing.T) {
@@ -775,17 +774,17 @@ func TestRegister_SendsVerificationEmail(t *testing.T) {
 		t.Errorf("expected recipient username in email body")
 	}
 
+	tok := emailedToken(t, email)
+
 	var stored model.User
 	if err := db.First(&stored, result.User.ID).Error; err != nil {
 		t.Fatalf("reload user: %v", err)
 	}
-	wantLink := "https://example.com/verify-email?token=" + stored.VerificationToken
-	if !strings.Contains(email.TextBody, wantLink) || !strings.Contains(email.HTMLBody, wantLink) {
-		t.Errorf("expected verification link %q in email body", wantLink)
+	if stored.VerificationToken != tokenStorageForm(tok) {
+		t.Errorf("expected only the token hash at rest, got %q", stored.VerificationToken)
 	}
 
 	// The emailed link actually verifies the address.
-	tok := extractToken(t, wantLink)
 	emailChange, _, err := svc.VerifyEmail(context.Background(), tok)
 	if err != nil {
 		t.Fatalf("VerifyEmail via link error: %v", err)
@@ -887,7 +886,7 @@ func TestResendVerification_NonVerifyTokensDoNotCoolDown(t *testing.T) {
 		Email:             "bob@example.com",
 		Password:          "hash",
 		Role:              model.RoleGuest,
-		VerificationToken: model.TokenPrefixReset + "abc",
+		VerificationToken: tokenStorageForm(model.TokenPrefixReset + "abc"),
 		TokenExpiresAt:    &expiresAt,
 	}
 	if err := db.Create(&u).Error; err != nil {
@@ -1035,20 +1034,20 @@ func TestUpdateEmail_SendsChangeEmail(t *testing.T) {
 		t.Errorf("expected new email in email body")
 	}
 
+	tok := emailedToken(t, email)
+	if !strings.HasPrefix(tok, model.TokenPrefixEmailChange) {
+		t.Fatalf("expected email-change token, got %q", tok)
+	}
+
 	var stored model.User
 	if err := db.First(&stored, u.ID).Error; err != nil {
 		t.Fatalf("reload user: %v", err)
 	}
-	if !strings.HasPrefix(stored.VerificationToken, model.TokenPrefixEmailChange) {
-		t.Fatalf("expected email-change token, got %q", stored.VerificationToken)
-	}
-	wantLink := "https://example.com/verify-email?token=" + stored.VerificationToken
-	if !strings.Contains(email.TextBody, wantLink) || !strings.Contains(email.HTMLBody, wantLink) {
-		t.Errorf("expected change link %q in email body", wantLink)
+	if stored.VerificationToken != tokenStorageForm(tok) {
+		t.Errorf("expected only the token hash at rest, got %q", stored.VerificationToken)
 	}
 
 	// The emailed link actually confirms the email change.
-	tok := extractToken(t, wantLink)
 	emailChange, newEmail, err := svc.VerifyEmail(context.Background(), tok)
 	if err != nil {
 		t.Fatalf("VerifyEmail via link error: %v", err)
@@ -1082,20 +1081,20 @@ func TestRequestPasswordReset_SendsResetEmail(t *testing.T) {
 		t.Errorf("unexpected subject %q", email.Subject)
 	}
 
+	tok := emailedToken(t, email)
+	if !strings.HasPrefix(tok, model.TokenPrefixReset) {
+		t.Fatalf("expected reset token, got %q", tok)
+	}
+
 	var stored model.User
 	if err := db.First(&stored, u.ID).Error; err != nil {
 		t.Fatalf("reload user: %v", err)
 	}
-	if !strings.HasPrefix(stored.VerificationToken, model.TokenPrefixReset) {
-		t.Fatalf("expected reset token, got %q", stored.VerificationToken)
-	}
-	wantLink := "https://example.com/reset-password?token=" + stored.VerificationToken
-	if !strings.Contains(email.TextBody, wantLink) || !strings.Contains(email.HTMLBody, wantLink) {
-		t.Errorf("expected reset link %q in email body", wantLink)
+	if stored.VerificationToken != tokenStorageForm(tok) {
+		t.Errorf("expected only the token hash at rest, got %q", stored.VerificationToken)
 	}
 
 	// The emailed link actually resets the password.
-	tok := extractToken(t, wantLink)
 	if err := svc.ResetPassword(context.Background(), tok, "brandnew123"); err != nil {
 		t.Fatalf("ResetPassword error: %v", err)
 	}
@@ -1130,7 +1129,7 @@ func TestVerifyEmail_Success(t *testing.T) {
 	u := model.User{
 		Username:          "alice",
 		Email:             "alice@example.com",
-		VerificationToken: "verify-abc",
+		VerificationToken: tokenStorageForm("verify-abc"),
 		TokenExpiresAt:    &expiresAt,
 		EmailVerified:     false,
 	}
@@ -1167,7 +1166,7 @@ func TestVerifyEmail_EmailChangeReturnsNewEmail(t *testing.T) {
 	u := model.User{
 		Username:          "alice",
 		Email:             "old@example.com",
-		VerificationToken: "email-change-abc",
+		VerificationToken: tokenStorageForm("email-change-abc"),
 		TokenExpiresAt:    &expiresAt,
 		PendingEmail:      "new@example.com",
 		EmailVerified:     true,
@@ -1205,7 +1204,7 @@ func TestVerifyEmail_RejectsResetToken(t *testing.T) {
 	u := model.User{
 		Username:          "alice",
 		Email:             "alice@example.com",
-		VerificationToken: "reset-abc",
+		VerificationToken: tokenStorageForm("reset-abc"),
 		TokenExpiresAt:    &expiresAt,
 		EmailVerified:     false,
 	}
@@ -1243,5 +1242,48 @@ func TestVerificationStatus(t *testing.T) {
 
 	if _, _, err := svc.VerificationStatus(context.Background(), 99999); !errors.Is(err, ErrUserNotFound) {
 		t.Errorf("expected ErrUserNotFound, got %v", err)
+	}
+}
+
+// TestTokens_OnlyHashesAreStored ensures the emailed account tokens exist in
+// the database only in their hashed storage form: a database leak must not
+// expose live one-time tokens, and the raw value must still resolve through
+// the hashed lookup.
+func TestTokens_OnlyHashesAreStored(t *testing.T) {
+	svc, _, db := newTestService(t)
+	u := seedUser(t, db, "alice@example.com", "password123", model.RoleGuest, true)
+
+	raw, err := svc.GenerateVerificationToken(context.Background(), u.ID)
+	if err != nil {
+		t.Fatalf("GenerateVerificationToken error: %v", err)
+	}
+
+	var stored model.User
+	if err := db.First(&stored, u.ID).Error; err != nil {
+		t.Fatalf("failed to reload user: %v", err)
+	}
+	if stored.VerificationToken == raw {
+		t.Error("raw token must not be stored in plaintext")
+	}
+	if !strings.HasPrefix(stored.VerificationToken, model.TokenPrefixVerify) {
+		t.Errorf("expected kind prefix preserved on stored hash, got %q", stored.VerificationToken)
+	}
+	hashPart := strings.TrimPrefix(stored.VerificationToken, model.TokenPrefixVerify)
+	if len(hashPart) != 64 { // hex-encoded SHA-256
+		t.Errorf("expected 64-char hex hash, got %d chars", len(hashPart))
+	}
+
+	// the raw token still resolves through the hashed lookup
+	user, err := svc.repo.FindUserByToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("FindUserByToken with raw token: %v", err)
+	}
+	if user.ID != u.ID {
+		t.Errorf("expected user %d, got %d", u.ID, user.ID)
+	}
+
+	// unknown tokens hash to something that matches nothing
+	if _, err := svc.repo.FindUserByToken(context.Background(), model.TokenPrefixVerify+"nope"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("expected ErrRecordNotFound for unknown token, got %v", err)
 	}
 }

--- a/backend/internal/comment/handler.go
+++ b/backend/internal/comment/handler.go
@@ -3,6 +3,7 @@ package comment
 import (
 	"errors"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -65,12 +66,25 @@ func (h *Handler) CreateComment(c *gin.Context) {
 	var postID uint
 	switch v := req.PostID.(type) {
 	case float64:
+		// JSON numbers decode as float64; reject out-of-range or negative
+		// values instead of letting the conversion wrap into garbage IDs.
+		if v < 1 || v > math.MaxUint32 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid postId"})
+			return
+		}
 		postID = uint(v)
 	case string:
-		if id64, err := strconv.ParseUint(v, 10, 64); err == nil {
-			postID = uint(id64)
+		id64, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid postId"})
+			return
 		}
+		postID = uint(id64)
 	case int:
+		if v < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid postId"})
+			return
+		}
 		postID = uint(v)
 	case uint:
 		postID = v

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -36,6 +36,12 @@ type Config struct {
 	// the unauthenticated captcha endpoints. 0 disables the limit.
 	CaptchaRateLimitPerMinute int `mapstructure:"captcha_rate_limit_per_minute"`
 
+	// AuthRateLimitPerMinute caps the requests per client IP per minute on the
+	// unauthenticated auth endpoints (register, login, password reset and
+	// verification resend) to slow down online brute-force and mail-bombing.
+	// 0 disables the limit.
+	AuthRateLimitPerMinute int `mapstructure:"auth_rate_limit_per_minute"`
+
 	// BaseURL is the public origin of this instance (e.g., https://vexgo.example.com).
 	// Used to build absolute links: SSO/OAuth callbacks and emailed
 	// verification / password-reset / email-change links. Empty means the
@@ -118,6 +124,7 @@ var keyDefaults = map[string]any{
 	"base_url":  "",
 
 	"captcha_rate_limit_per_minute": 30,
+	"auth_rate_limit_per_minute":    10,
 
 	"db_type":     "",
 	"db_host":     "",

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -156,7 +156,10 @@ func openPostgres(cfg *config.Config) (*gorm.DB, error) {
 
 // openSQLite connects to an SQLite database stored in dataDir.
 func openSQLite(dataDir string) (*gorm.DB, error) {
-	if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
+	// 0750: the directory holds blog.db (user credentials, sessions, private
+	// posts), so it must not be group/world traversable. MkdirAll is a no-op
+	// for an existing directory, so this only affects fresh deployments.
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return nil, fmt.Errorf("create data directory: %w", err)
 	}
 	dbPath := filepath.Join(dataDir, "blog.db")

--- a/backend/internal/middleware/logger.go
+++ b/backend/internal/middleware/logger.go
@@ -3,10 +3,41 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+// redactedQueryParams are query parameters whose values are credentials and
+// must not end up in access logs.
+var redactedQueryParams = map[string]struct{}{
+	"token": {},
+}
+
+// sanitizeQuery strips credential-bearing query parameters (e.g. the emailed
+// verification / reset token in ?token=...) before the URL is logged.
+func sanitizeQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		// Unparseable query: drop it rather than risk logging a token.
+		return ""
+	}
+	redacted := false
+	for key := range values {
+		if _, sensitive := redactedQueryParams[key]; sensitive {
+			values[key] = []string{"[REDACTED]"}
+			redacted = true
+		}
+	}
+	if !redacted {
+		return rawQuery
+	}
+	return values.Encode()
+}
 
 // RequestLogger is a Gin middleware that logs HTTP requests and responses
 func RequestLogger() gin.HandlerFunc {
@@ -15,8 +46,7 @@ func RequestLogger() gin.HandlerFunc {
 
 		// Get request details
 		path := c.Request.URL.Path
-		raw := c.Request.URL.RawQuery
-		if raw != "" {
+		if raw := sanitizeQuery(c.Request.URL.RawQuery); raw != "" {
 			path += "?" + raw
 		}
 

--- a/backend/internal/middleware/pagination.go
+++ b/backend/internal/middleware/pagination.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// DefaultPaginationLimit is used when the limit parameter is absent or invalid.
+	DefaultPaginationLimit = 10
+	// MaxPaginationLimit caps the page size so a client cannot request an
+	// unbounded dump of a table.
+	MaxPaginationLimit = 100
+)
+
+// ParsePagination reads the "page" and "limit" query parameters and clamps
+// them to safe ranges: page < 1 becomes 1, limit < 1 becomes defaultLimit and
+// limit above 100 is capped. Handlers must not use raw query values in
+// Offset/Limit calls — a negative limit makes GORM drop the LIMIT clause
+// entirely, and a zero limit panics on the subsequent totalPages division.
+func ParsePagination(c *gin.Context, defaultLimit int) (page, limit int) {
+	if defaultLimit < 1 {
+		defaultLimit = DefaultPaginationLimit
+	}
+
+	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if err != nil || page < 1 {
+		page = 1
+	}
+
+	limit, err = strconv.Atoi(c.DefaultQuery("limit", strconv.Itoa(defaultLimit)))
+	if err != nil || limit < 1 {
+		limit = defaultLimit
+	}
+	if limit > MaxPaginationLimit {
+		limit = MaxPaginationLimit
+	}
+	return page, limit
+}

--- a/backend/internal/middleware/pagination_test.go
+++ b/backend/internal/middleware/pagination_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestParsePagination_ClampsUnsafeValues(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name         string
+		query        string
+		defaultLimit int
+		wantPage     int
+		wantLimit    int
+	}{
+		{"defaults", "", 10, 1, 10},
+		{"valid", "page=3&limit=25", 10, 3, 25},
+		{"zero limit falls back", "page=1&limit=0", 10, 1, 10},
+		{"negative limit falls back", "limit=-1", 10, 1, 10},
+		{"zero page becomes 1", "page=0", 10, 1, 10},
+		{"negative page becomes 1", "page=-5", 10, 1, 10},
+		{"non-numeric falls back", "page=abc&limit=xyz", 10, 1, 10},
+		{"limit capped at max", "limit=10000", 10, 1, 100},
+		{"small default respected", "limit=0", 5, 1, 5},
+		{"invalid default becomes standard", "limit=0", -3, 1, 10},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest("GET", "/?"+tc.query, nil)
+
+			page, limit := ParsePagination(c, tc.defaultLimit)
+			if page != tc.wantPage || limit != tc.wantLimit {
+				t.Errorf("ParsePagination(%q) = (%d, %d), want (%d, %d)",
+					tc.query, page, limit, tc.wantPage, tc.wantLimit)
+			}
+		})
+	}
+}

--- a/backend/internal/middleware/security_headers.go
+++ b/backend/internal/middleware/security_headers.go
@@ -1,0 +1,16 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+// SecurityHeaders sets baseline browser defenses on every response. It is
+// deliberately conservative (no CSP, which needs per-deployment tuning): these
+// headers mainly stop uploaded or proxied content from being sniffed into
+// executable documents and from being framed by third parties.
+func SecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "SAMEORIGIN")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Next()
+	}
+}

--- a/backend/internal/notification/handler.go
+++ b/backend/internal/notification/handler.go
@@ -25,8 +25,7 @@ func NewHandler(deps Deps) *Handler {
 func (h *Handler) GetNotifications(c *gin.Context) {
 	uid := middleware.CurrentUserID(c)
 
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 
 	notifications, total, err := h.svc.List(c.Request.Context(), ListQuery{
 		UserID:           uid,

--- a/backend/internal/post/handler.go
+++ b/backend/internal/post/handler.go
@@ -26,14 +26,7 @@ func NewHandler(deps Deps) *Handler {
 
 // GetPosts returns the post list.
 func (h *Handler) GetPosts(c *gin.Context) {
-	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
-	if err != nil || page < 1 {
-		page = 1
-	}
-	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
-	if err != nil || limit < 1 || limit > 100 {
-		limit = 10
-	}
+	page, limit := middleware.ParsePagination(c, 10)
 
 	u, _ := middleware.CurrentUser(c)
 	userRole, userID := u.Role, u.ID
@@ -248,8 +241,7 @@ func (h *Handler) DeletePost(c *gin.Context) {
 func (h *Handler) GetMyPosts(c *gin.Context) {
 	userID := middleware.CurrentUserID(c)
 
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 	status := c.DefaultQuery("status", "")
 
 	posts, total, err := h.svc.MyPosts(c.Request.Context(), MyPostsQuery{
@@ -281,8 +273,7 @@ func (h *Handler) GetMyPosts(c *gin.Context) {
 
 // GetDraftPosts returns draft posts.
 func (h *Handler) GetDraftPosts(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 
 	u, _ := middleware.CurrentUser(c)
 	userRole, userID := u.Role, u.ID
@@ -317,8 +308,7 @@ func (h *Handler) GetDraftPosts(c *gin.Context) {
 // GetUserPosts returns the posts of a specific user.
 func (h *Handler) GetUserPosts(c *gin.Context) {
 	userIDStr := c.Param("id")
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 
 	u, _ := middleware.CurrentUser(c)
 	userRole, userID := u.Role, u.ID
@@ -359,7 +349,7 @@ func (h *Handler) GetUserPosts(c *gin.Context) {
 func (h *Handler) GetPopularPosts(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	userRole := u.Role
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
+	_, limit := middleware.ParsePagination(c, 5)
 
 	posts, err := h.svc.Popular(c.Request.Context(), userRole, limit)
 	if err != nil {
@@ -378,7 +368,7 @@ func (h *Handler) GetPopularPosts(c *gin.Context) {
 func (h *Handler) GetLatestPosts(c *gin.Context) {
 	u, _ := middleware.CurrentUser(c)
 	userRole := u.Role
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
+	_, limit := middleware.ParsePagination(c, 5)
 
 	posts, err := h.svc.Latest(c.Request.Context(), userRole, limit)
 	if err != nil {
@@ -581,8 +571,7 @@ func (h *Handler) GetRejectedPosts(c *gin.Context) {
 
 // listModeration renders the moderation queue for a given post status.
 func (h *Handler) listModeration(c *gin.Context, status model.PostStatus) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 	search := c.DefaultQuery("search", "")
 
 	posts, total, err := h.svc.ListModeration(c.Request.Context(), ListModerationQuery{

--- a/backend/internal/public/public.go
+++ b/backend/internal/public/public.go
@@ -295,9 +295,13 @@ func (r *Renderer) RegisterStaticRoutes(e *gin.Engine, s3Enabled bool) {
 			return
 		}
 
-		// Server-side rendering: lookup by slug
+		// Server-side rendering: lookup by slug. Drafts, pending and rejected
+		// posts stay hidden — the SSR page must not expose them via a
+		// guessable slug when the API filters them out.
 		var post model.Post
-		if err := r.db.Preload("Author").Preload("Tags").Where("slug = ?", slug).First(&post).Error; err != nil {
+		if err := r.db.Preload("Author").Preload("Tags").
+			Where("slug = ? AND status = ?", slug, model.PostStatusPublished).
+			First(&post).Error; err != nil {
 			// Post not found, serve SPA so the frontend can render a 404 page.
 			c.Data(http.StatusNotFound, "text/html; charset=utf-8", GetIndexHTML())
 			return
@@ -325,9 +329,12 @@ func (r *Renderer) RegisterStaticRoutes(e *gin.Engine, s3Enabled bool) {
 			return
 		}
 
-		// Server-side rendering: lookup by slug
+		// Server-side rendering: lookup by slug (published posts only, see the
+		// plural route above)
 		var post model.Post
-		if err := r.db.Preload("Author").Preload("Tags").Where("slug = ?", slug).First(&post).Error; err != nil {
+		if err := r.db.Preload("Author").Preload("Tags").
+			Where("slug = ? AND status = ?", slug, model.PostStatusPublished).
+			First(&post).Error; err != nil {
 			c.Data(http.StatusNotFound, "text/html; charset=utf-8", GetIndexHTML())
 			return
 		}

--- a/backend/internal/public/public.go
+++ b/backend/internal/public/public.go
@@ -168,8 +168,10 @@ func (r *Renderer) activeTheme() string {
 	return config.ActiveTheme
 }
 
-// isSafePath verifies that targetPath is within basePath
-func isSafePath(basePath, targetPath string) bool {
+// IsPathInside verifies that targetPath is within basePath. Exported because
+// other domains resolve untrusted paths against theme directories too (e.g.
+// settings theme previews) and must apply the same containment check.
+func IsPathInside(basePath, targetPath string) bool {
 	absBase, err := filepath.Abs(basePath)
 	if err != nil {
 		return false
@@ -216,7 +218,7 @@ func (r *Renderer) getFileContent(themeID, relativePath string) ([]byte, string,
 		}
 
 		themeBasePath := filepath.Join(r.dataDir, ThemesDir, themeID)
-		if !isSafePath(themeBasePath, cleanPath) {
+		if !IsPathInside(themeBasePath, cleanPath) {
 			return nil, "", false
 		}
 

--- a/backend/internal/settings/handler.go
+++ b/backend/internal/settings/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/vexgo-org/vexgo/backend/internal/middleware"
@@ -16,6 +17,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
+
+// themeIDPattern is the allowlist for theme directory names coming from
+// uploaded theme metadata: letters, digits, underscore and dash only, so the
+// value can never traverse out of the themes directory.
+var themeIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // Handler exposes the settings domain over HTTP.
 type Handler struct {
@@ -467,8 +473,11 @@ func (h *Handler) UploadTheme(c *gin.Context) {
 		}
 	}
 
-	// Ensure the theme ID is valid
-	if themeDir == "" || themeDir == public.DefaultTheme {
+	// Ensure the theme ID is valid. The ID may come from the uploaded
+	// vexgo-theme.json, so it is treated as untrusted input: anything but a
+	// plain directory name would make filepath.Join below escape the themes
+	// directory (arbitrary RemoveAll/MkdirAll/write).
+	if themeDir == "" || themeDir == public.DefaultTheme || !themeIDPattern.MatchString(themeDir) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid theme ID"})
 		return
 	}

--- a/backend/internal/settings/handler.go
+++ b/backend/internal/settings/handler.go
@@ -358,30 +358,42 @@ func (h *Handler) UploadTheme(c *gin.Context) {
 		return
 	}
 
-	// Extract the zip file
+	// Extract the zip file. Entry names are untrusted input: os.Root confines
+	// every created file to the extraction directory at the OS level, so
+	// absolute paths, ".." segments or volume names in entries cannot escape
+	// tempDir. The Clean/IsAbs/".." pre-check below only fails fast with a
+	// client-facing 400; the Root is the actual guarantee.
+	zipRoot, err := os.OpenRoot(tempDir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to prepare extraction directory"})
+		return
+	}
+	defer func() { _ = zipRoot.Close() }()
+
 	for _, f := range zipReader.File {
 		if f.FileInfo().IsDir() {
 			continue
 		}
 
 		// Ensure the file path is safe
-		if strings.Contains(f.Name, "..") {
+		clean := filepath.Clean(f.Name)
+		if filepath.IsAbs(clean) || strings.Contains(clean, "..") {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file path in zip"})
 			return
 		}
 
-		// Create the directory structure
-		filePath := filepath.Join(tempDir, f.Name)
-		dir := filepath.Dir(filePath)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create directory structure"})
-			return
+		// Create the directory structure inside the extraction root
+		if dir := filepath.Dir(clean); dir != "." {
+			if err := zipRoot.MkdirAll(dir, 0o755); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file path in zip"})
+				return
+			}
 		}
 
 		// Extract the file
-		dstFile, err := os.Create(filePath)
+		dstFile, err := zipRoot.Create(clean)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create file"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file path in zip"})
 			return
 		}
 

--- a/backend/internal/settings/handler_test.go
+++ b/backend/internal/settings/handler_test.go
@@ -1,7 +1,10 @@
 package settings
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -222,5 +225,91 @@ func TestSMTPRoutes_TestSendWorksWithEncryptedPassword(t *testing.T) {
 	}
 	if capture.to != "to@example.com" {
 		t.Errorf("expected a captured test email to %q, got %q", "to@example.com", capture.to)
+	}
+}
+
+// buildThemeZip packs the given entries (name → content) into a zip archive.
+func buildThemeZip(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// doThemeUpload POSTs a zip to the admin theme upload endpoint.
+func doThemeUpload(t *testing.T, r *gin.Engine, token string, zipBytes []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("theme", "theme.zip")
+	if err != nil {
+		t.Fatalf("multipart form file: %v", err)
+	}
+	if _, err := fw.Write(zipBytes); err != nil {
+		t.Fatalf("multipart write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("multipart close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/themes/upload", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestUploadTheme_RejectsZipSlipEntries ensures hostile zip entry names —
+// relative traversal, absolute paths and Windows-style traversal — are
+// rejected with 400 instead of being extracted.
+func TestUploadTheme_RejectsZipSlipEntries(t *testing.T) {
+	r, _, _ := newTestAdminRouter(t)
+	token := mintAdminToken(t)
+
+	for name, entry := range map[string]string{
+		"parent traversal":     "../evil.txt",
+		"nested traversal":     "assets/../../evil.txt",
+		"absolute path":        "/tmp/vexgo-evil.txt",
+		"windows traversal":    `..\..\evil.txt`,
+		"windows drive letter": `C:\vexgo-evil.txt`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			zipBytes := buildThemeZip(t, map[string]string{entry: "evil"})
+			w := doThemeUpload(t, r, token, zipBytes)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for entry %q, got %d: %s", entry, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestUploadTheme_AcceptsWellFormedZip exercises the happy path: a zip with a
+// valid vexgo-theme.json and nested assets installs successfully.
+func TestUploadTheme_AcceptsWellFormedZip(t *testing.T) {
+	r, _, _ := newTestAdminRouter(t)
+	token := mintAdminToken(t)
+
+	zipBytes := buildThemeZip(t, map[string]string{
+		"vexgo-theme.json":    `{"id": "testtheme", "name": "Test Theme"}`,
+		"assets/style.css":    "body {}",
+		"templates/home.html": "<html></html>",
+	})
+
+	w := doThemeUpload(t, r, token, zipBytes)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/settings/service.go
+++ b/backend/internal/settings/service.go
@@ -708,8 +708,15 @@ func (s *Service) ThemePreview(themeID string) (string, error) {
 		return "", ErrPreviewNotSpecified
 	}
 
-	// Build preview image path
-	previewPath := filepath.Join(s.themes.DataDir(), public.ThemesDir, themeID, themeInfo.Preview)
+	// Build preview image path. Preview comes from the theme's own metadata,
+	// so treat it as untrusted: reject anything that escapes the theme
+	// directory ("../../etc/passwd" would otherwise be served verbatim).
+	themeBasePath := filepath.Join(s.themes.DataDir(), public.ThemesDir, themeID)
+	cleanPreview := filepath.Clean(themeInfo.Preview)
+	if !public.IsPathInside(themeBasePath, cleanPreview) {
+		return "", ErrPreviewNotFound
+	}
+	previewPath := filepath.Join(themeBasePath, cleanPreview)
 
 	// Check if preview image exists
 	if _, err := os.Stat(previewPath); os.IsNotExist(err) {

--- a/backend/internal/settings/service_test.go
+++ b/backend/internal/settings/service_test.go
@@ -3,6 +3,8 @@ package settings
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -502,5 +504,30 @@ func TestTestAI_UndecryptableKeyTreatedAsUnset(t *testing.T) {
 
 	if _, err := svc.TestAI(context.Background()); !errors.Is(err, ErrAIIncomplete) {
 		t.Errorf("expected ErrAIIncomplete for undecryptable key, got %v", err)
+	}
+}
+
+// TestThemePreview_RejectsEscapingPreviewPath ensures a malicious theme
+// metadata cannot make the public preview endpoint serve files outside the
+// theme directory (arbitrary file read).
+func TestThemePreview_RejectsEscapingPreviewPath(t *testing.T) {
+	svc, _ := newTestService(t)
+	dataDir := svc.themes.DataDir()
+
+	themeID := "evil"
+	themeDir := filepath.Join(dataDir, public.ThemesDir, themeID)
+	if err := os.MkdirAll(themeDir, 0o755); err != nil {
+		t.Fatalf("mkdir error: %v", err)
+	}
+	meta := `{"id": "evil", "preview": "../../secret.txt"}`
+	if err := os.WriteFile(filepath.Join(themeDir, public.ThemeMetaFile), []byte(meta), 0o600); err != nil {
+		t.Fatalf("write meta error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "secret.txt"), []byte("top secret"), 0o600); err != nil {
+		t.Fatalf("write secret error: %v", err)
+	}
+
+	if _, err := svc.ThemePreview(themeID); !errors.Is(err, ErrPreviewNotFound) {
+		t.Errorf("expected ErrPreviewNotFound for escaping preview path, got %v", err)
 	}
 }

--- a/backend/internal/sso/service.go
+++ b/backend/internal/sso/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/vexgo-org/vexgo/backend/internal/auth"
 	"github.com/vexgo-org/vexgo/backend/internal/config"
+	"github.com/vexgo-org/vexgo/backend/internal/mailer"
 	"github.com/vexgo-org/vexgo/backend/internal/model"
 
 	"github.com/coreos/go-oidc"
@@ -50,15 +52,26 @@ var (
 
 // generateState creates a random one-time state for CSRF protection and
 // stores it keyed by provider, bound to the client IP and requested method.
-func generateState(provider, ip, method string) string {
+// Expired entries are swept opportunistically so abandoned flows cannot grow
+// the cache without bound.
+func generateState(provider, ip, method string) (string, error) {
 	b := make([]byte, stateLength)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate sso state: %w", err)
+	}
 	state := base64.URLEncoding.EncodeToString(b)[:stateLength]
 	key := provider + "_" + state
+
+	now := time.Now()
 	stateMu.Lock()
-	stateCache[key] = stateEntry{ip: ip, method: method, expires: time.Now().Add(stateExpire)}
+	for k, entry := range stateCache {
+		if now.After(entry.expires) {
+			delete(stateCache, k)
+		}
+	}
+	stateCache[key] = stateEntry{ip: ip, method: method, expires: now.Add(stateExpire)}
 	stateMu.Unlock()
-	return state
+	return state, nil
 }
 
 // verifyState consumes and validates a state previously issued by
@@ -83,6 +96,10 @@ type Deps struct {
 	DB        *gorm.DB
 	SSO       *config.SSOConfig
 	JWTSecret []byte
+	// Mailer is consulted when deciding whether a local account may be linked
+	// to an SSO identity by email: with SMTP disabled there is no verification
+	// flow, so unverified local accounts stay linkable (see linkableByEmail).
+	Mailer *mailer.Service
 
 	// BaseURL is the public origin of this instance (cfg.BaseURL). When set,
 	// OAuth callback URLs are built from it instead of the request host.
@@ -94,12 +111,32 @@ type Service struct {
 	repo      Repository
 	sso       *config.SSOConfig
 	jwtSecret []byte
+	mailer    *mailer.Service
 	baseURL   string
 }
 
 // NewService creates an sso service with the given dependencies.
 func NewService(deps Deps) *Service {
-	return &Service{repo: NewRepository(deps.DB), sso: deps.SSO, jwtSecret: deps.JWTSecret, baseURL: deps.BaseURL}
+	return &Service{repo: NewRepository(deps.DB), sso: deps.SSO, jwtSecret: deps.JWTSecret, mailer: deps.Mailer, baseURL: deps.BaseURL}
+}
+
+// linkableByEmail reports whether a local account may be linked to an SSO
+// identity whose email the provider verified. The local account must be
+// verified itself, unless SMTP is disabled and no verification flow exists.
+func (s *Service) linkableByEmail(ctx context.Context, u *model.User) (bool, error) {
+	if u.EmailVerified {
+		return true, nil
+	}
+	if s.mailer == nil {
+		return false, nil
+	}
+	enabled, err := s.mailer.Enabled(ctx)
+	if err != nil {
+		// The verification state of the account cannot be confirmed; stay
+		// strict rather than linking on a maybe.
+		return false, nil
+	}
+	return !enabled, nil
 }
 
 // Providers returns the list of enabled providers and whether local login is
@@ -127,7 +164,10 @@ func (s *Service) LoginRedirect(c *gin.Context, provider, method string) (authUR
 	}
 
 	redirectURI := s.callbackURI(c, provider)
-	state := generateState(provider, c.ClientIP(), method)
+	state, err := generateState(provider, c.ClientIP(), method)
+	if err != nil {
+		return "", http.StatusInternalServerError, "failed to start login flow"
+	}
 
 	switch provider {
 	case "github":
@@ -146,7 +186,8 @@ func (s *Service) LoginRedirect(c *gin.Context, provider, method string) (authUR
 		}
 		oidcCfg, err := s.oidcOAuth2Config(c.Request.Context(), redirectURI)
 		if err != nil {
-			return "", http.StatusInternalServerError, err.Error()
+			slog.Warn("oidc discovery failed", "err", err)
+			return "", http.StatusInternalServerError, "SSO provider is temporarily unavailable"
 		}
 		authURL = oidcCfg.AuthCodeURL(state)
 	default:
@@ -174,7 +215,10 @@ func (s *Service) Callback(c *gin.Context, provider, state, code string) (payloa
 	redirectURI := s.callbackURI(c, provider)
 	info, err := s.exchange(c, provider, code, redirectURI)
 	if err != nil {
-		return nil, err.Error()
+		// Details may contain provider response bodies and internal URLs;
+		// log them server-side and return a generic message to the client.
+		slog.Warn("sso exchange failed", "provider", provider, "err", err)
+		return nil, "login with the provider failed, please try again"
 	}
 
 	// get_sso_id: just return the provider-scoped ID so the frontend can bind it
@@ -187,7 +231,8 @@ func (s *Service) Callback(c *gin.Context, provider, state, code string) (payloa
 	// sso_get_token: find or create local user, then issue JWT
 	user, err := s.FindOrCreateUser(c.Request.Context(), provider, info)
 	if err != nil {
-		return nil, err.Error()
+		slog.Warn("sso account resolution failed", "provider", provider, "err", err)
+		return nil, "failed to resolve the account for this login"
 	}
 	token, err := auth.IssueJWT(user, s.jwtSecret)
 	if err != nil {
@@ -282,6 +327,11 @@ type ssoUserInfo struct {
 	username   string
 	email      string
 	avatar     string
+	// emailVerified reports whether the provider confirmed ownership of
+	// info.email. It is only true on explicit confirmation (GitHub /user/emails
+	// verified flag, Google/OIDC email_verified claim); providers that stay
+	// silent count as unverified so email-based account linking stays safe.
+	emailVerified bool
 }
 
 // exchange delegates the OAuth2 code exchange to the matching provider
@@ -328,9 +378,21 @@ func (s *Service) exchangeGitHub(c *gin.Context, code, redirectURI string) (*sso
 	info.email, _ = data["email"].(string)
 	info.avatar, _ = data["avatar_url"].(string)
 
-	// GitHub may omit email in /user when it is set to private
+	// GitHub may omit email in /user when it is set to private. The /user
+	// endpoint alone does not prove ownership, so confirmation comes from
+	// /user/emails: either the address we got is flagged verified there, or
+	// the account's verified primary email replaces it.
+	if emails := fetchGitHubEmails(tok.AccessToken); emails != nil {
+		if isVerifiedGitHubEmail(emails, info.email) {
+			info.emailVerified = true
+		} else if primary := verifiedGitHubPrimaryEmail(emails); primary != "" {
+			info.email = primary
+			info.emailVerified = true
+		}
+	}
 	if info.email == "" {
 		info.email = fetchGitHubPrimaryEmail(tok.AccessToken)
+		info.emailVerified = info.email != ""
 	}
 	if info.providerID == "" {
 		return nil, errors.New("cannot get user ID from GitHub")
@@ -360,6 +422,7 @@ func (s *Service) exchangeGoogle(c *gin.Context, code, redirectURI string) (*sso
 	info.username, _ = data["name"].(string)
 	info.email, _ = data["email"].(string)
 	info.avatar, _ = data["picture"].(string)
+	info.emailVerified, _ = data["email_verified"].(bool)
 
 	if info.providerID == "" {
 		return nil, errors.New("cannot get user ID from Google")
@@ -496,6 +559,9 @@ func (s *Service) claimsToUserInfo(claims map[string]any) *ssoUserInfo {
 	// email — respect OIDC_EMAIL_CLAIM
 	info.email, _ = claims[cfg.EmailClaim].(string)
 	info.avatar, _ = claims["picture"].(string)
+	if verified, ok := claims["email_verified"].(bool); ok {
+		info.emailVerified = verified
+	}
 	return info
 }
 
@@ -521,21 +587,41 @@ func (s *Service) FindOrCreateUser(ctx context.Context, provider string, info *s
 		return user, nil
 	}
 
-	// 2. Email match → link to existing account
+	// 2. Email match → link to existing account. Linking is only allowed when
+	// the provider confirmed the email (email_verified) AND the local account
+	// is verified itself — unless the instance has no verification flow at
+	// all (SMTP disabled), matching the fail-open stance of local login.
+	// Without these checks an attacker controlling an unverified SSO identity
+	// carrying a victim's email could log in as the victim.
 	var user *model.User
-	if info.email != "" {
-		if u, err := s.repo.FindUserByEmail(ctx, info.email); err == nil {
-			user = u
-			// Update last login time
-			user.LastLoginAt = time.Now()
-			if err := s.repo.SaveUser(ctx, user); err != nil {
+	emailTaken := false
+	if info.email != "" && info.emailVerified {
+		u, err := s.repo.FindUserByEmail(ctx, info.email)
+		switch {
+		case err == nil:
+			emailTaken = true
+			linkable, err := s.linkableByEmail(ctx, u)
+			if err != nil {
 				return nil, err
 			}
+			if linkable {
+				user = u
+				// Update last login time
+				user.LastLoginAt = time.Now()
+				if err := s.repo.SaveUser(ctx, user); err != nil {
+					return nil, err
+				}
+			}
+		case !errors.Is(err, gorm.ErrRecordNotFound):
+			return nil, err
 		}
 	}
 
 	// 3. Auto-register new user
 	if user == nil {
+		if emailTaken {
+			return nil, errors.New("an account with this email already exists; verify your email first or log in with a password")
+		}
 		username := s.generateUsername(ctx, info.username, info.email)
 		u := model.User{
 			Username:        username,
@@ -622,17 +708,37 @@ func apiGet(url, accessToken, scheme string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-// fetchGitHubPrimaryEmail returns the primary, verified email address from
-// GitHub's /user/emails endpoint, or an empty string when unavailable.
-func fetchGitHubPrimaryEmail(accessToken string) string {
+// fetchGitHubEmails returns the account's email entries from GitHub's
+// /user/emails endpoint, or nil when unavailable.
+func fetchGitHubEmails(accessToken string) []map[string]any {
 	body, err := apiGet("https://api.github.com/user/emails", accessToken, "token")
 	if err != nil {
-		return ""
+		return nil
 	}
 	var emails []map[string]any
 	if err := json.Unmarshal(body, &emails); err != nil {
-		return ""
+		return nil
 	}
+	return emails
+}
+
+// isVerifiedGitHubEmail reports whether the given address is flagged verified
+// in a /user/emails payload.
+func isVerifiedGitHubEmail(emails []map[string]any, email string) bool {
+	for _, e := range emails {
+		if addr, _ := e["email"].(string); addr != email {
+			continue
+		}
+		if verified, _ := e["verified"].(bool); verified {
+			return true
+		}
+	}
+	return false
+}
+
+// verifiedGitHubPrimaryEmail returns the primary, verified email address from
+// a /user/emails payload, or an empty string when unavailable.
+func verifiedGitHubPrimaryEmail(emails []map[string]any) string {
 	for _, e := range emails {
 		if primary, _ := e["primary"].(bool); !primary {
 			continue
@@ -645,6 +751,12 @@ func fetchGitHubPrimaryEmail(accessToken string) string {
 		}
 	}
 	return ""
+}
+
+// fetchGitHubPrimaryEmail returns the primary, verified email address from
+// GitHub's /user/emails endpoint, or an empty string when unavailable.
+func fetchGitHubPrimaryEmail(accessToken string) string {
+	return verifiedGitHubPrimaryEmail(fetchGitHubEmails(accessToken))
 }
 
 // isValidMethod reports whether the SSO flow method is supported.

--- a/backend/internal/sso/service_test.go
+++ b/backend/internal/sso/service_test.go
@@ -31,8 +31,12 @@ func newTestService(t *testing.T) (*Service, *gorm.DB) {
 }
 
 func seedUser(t *testing.T, db *gorm.DB, username, email string) model.User {
+	return seedUserVerified(t, db, username, email, false)
+}
+
+func seedUserVerified(t *testing.T, db *gorm.DB, username, email string, verified bool) model.User {
 	t.Helper()
-	u := model.User{Username: username, Email: email, Role: model.RoleGuest}
+	u := model.User{Username: username, Email: email, Role: model.RoleGuest, EmailVerified: verified}
 	if err := db.Create(&u).Error; err != nil {
 		t.Fatalf("failed to seed user: %v", err)
 	}
@@ -79,12 +83,13 @@ func TestFindOrCreateUser_ExactBinding(t *testing.T) {
 
 func TestFindOrCreateUser_EmailMatch(t *testing.T) {
 	svc, db := newTestService(t)
-	u := seedUser(t, db, "bob", "bob@example.com")
+	u := seedUserVerified(t, db, "bob", "bob@example.com", true)
 
 	user, err := svc.FindOrCreateUser(context.Background(), "google", &ssoUserInfo{
-		providerID: "g-456",
-		username:   "Bobby",
-		email:      "bob@example.com",
+		providerID:    "g-456",
+		username:      "Bobby",
+		email:         "bob@example.com",
+		emailVerified: true,
 	})
 	if err != nil {
 		t.Fatalf("FindOrCreateUser error: %v", err)
@@ -101,6 +106,54 @@ func TestFindOrCreateUser_EmailMatch(t *testing.T) {
 	if binding.UserID != u.ID {
 		t.Errorf("expected binding to bob")
 	}
+}
+
+// TestFindOrCreateUser_EmailLinkRequiresVerifiedEmail ensures an SSO identity
+// carrying an unverified email cannot link to (and thereby take over) an
+// existing local account.
+func TestFindOrCreateUser_EmailLinkRequiresVerifiedEmail(t *testing.T) {
+	t.Run("provider email unverified", func(t *testing.T) {
+		svc, db := newTestService(t)
+		seedUserVerified(t, db, "bob", "bob@example.com", true)
+
+		_, err := svc.FindOrCreateUser(context.Background(), "google", &ssoUserInfo{
+			providerID:    "g-789",
+			username:      "Bobby",
+			email:         "bob@example.com",
+			emailVerified: false,
+		})
+		if err == nil {
+			t.Fatal("expected error for unverified provider email, got nil")
+		}
+
+		// no binding may have been created for the attacker identity
+		var bindings int64
+		db.Model(&model.SSOBinding{}).Where("provider_id = ?", "g-789").Count(&bindings)
+		if bindings != 0 {
+			t.Errorf("expected no binding, got %d", bindings)
+		}
+	})
+
+	t.Run("local account unverified", func(t *testing.T) {
+		svc, db := newTestService(t)
+		seedUserVerified(t, db, "bob", "bob@example.com", false)
+
+		_, err := svc.FindOrCreateUser(context.Background(), "google", &ssoUserInfo{
+			providerID:    "g-990",
+			username:      "Bobby",
+			email:         "bob@example.com",
+			emailVerified: true,
+		})
+		if err == nil {
+			t.Fatal("expected error for unverified local account, got nil")
+		}
+
+		var bindings int64
+		db.Model(&model.SSOBinding{}).Where("provider_id = ?", "g-990").Count(&bindings)
+		if bindings != 0 {
+			t.Errorf("expected no binding, got %d", bindings)
+		}
+	})
 }
 
 func TestFindOrCreateUser_AutoRegister(t *testing.T) {

--- a/backend/internal/upload/handler.go
+++ b/backend/internal/upload/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/vexgo-org/vexgo/backend/internal/model"
 
@@ -39,12 +40,34 @@ func getFileExtension(filename string) string {
 	return ext
 }
 
+// maxExtensionLength caps the client-supplied extension length so a hostile
+// filename cannot push the stored name past filesystem limits.
+const maxExtensionLength = 9
+
+// sanitizeExtension extracts the client-supplied extension and keeps it only
+// if it is 1-9 lowercase ASCII letters/digits. It is the only client-controlled
+// part of the stored filename, so anything else (separators, spaces, control
+// bytes, Windows ADS colons, overlong tails) means no extension at all.
+func sanitizeExtension(filename string) string {
+	ext := strings.TrimPrefix(getFileExtension(filename), ".")
+	if ext == "" || len(ext) > maxExtensionLength {
+		return ""
+	}
+	ext = strings.ToLower(ext)
+	for i := 0; i < len(ext); i++ {
+		c := ext[i]
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return ""
+		}
+	}
+	return "." + ext
+}
+
 // generateFilename generates a unique filename with extension
 func generateFilename(originalName string) string {
-	ext := getFileExtension(originalName)
 	uid := uuid.New().String()
-	if ext != "" {
-		return fmt.Sprintf("%s%s", uid, ext)
+	if ext := sanitizeExtension(originalName); ext != "" {
+		return uid + ext
 	}
 	return uid
 }

--- a/backend/internal/upload/handler_test.go
+++ b/backend/internal/upload/handler_test.go
@@ -1,0 +1,102 @@
+package upload
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestGenerateFilename_SanitizesExtension ensures the client-supplied
+// extension survives only as a short alphanumeric suffix; anything else
+// (separators, HTML, colons, overlong tails) yields a bare UUID name.
+func TestGenerateFilename_SanitizesExtension(t *testing.T) {
+	cases := []struct {
+		name     string
+		original string
+		wantExt  string
+	}{
+		{"plain jpg", "photo.jpg", ".jpg"},
+		{"uppercase normalized", "PHOTO.JPG", ".jpg"},
+		{"multi-dot takes last", "archive.tar.gz", ".gz"},
+		{"no extension", "noext", ""},
+		{"dot only", "x.", ""},
+		{"html injection", "x.<script>", ""},
+		{"windows ADS colon", "x.jpg:b", ""},
+		{"backslash traversal", `x.\evil.jpg`, ".jpg"},
+		{"overlong extension", "x." + strings.Repeat("a", 50), ""},
+		{"dashes rejected", "x.tar-gz", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generateFilename(tc.original)
+
+			if tc.wantExt == "" {
+				if isUUID(got) {
+					return
+				}
+				t.Errorf("expected bare UUID name, got %q", got)
+				return
+			}
+			if !strings.HasSuffix(got, tc.wantExt) {
+				t.Fatalf("expected suffix %q, got %q", tc.wantExt, got)
+			}
+			base := strings.TrimSuffix(got, tc.wantExt)
+			if !isUUID(base) {
+				t.Errorf("expected UUID base name, got %q", base)
+			}
+		})
+	}
+}
+
+func isUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
+}
+
+// TestLocalStorage_ContainsHostileFilenames ensures os.Root confinement:
+// hostile filenames can never create or delete files outside the media
+// directory. Upload rejects separator-carrying names outright; the ".." name
+// has no separator and is what the os.Root layer refuses.
+func TestLocalStorage_ContainsHostileFilenames(t *testing.T) {
+	dataDir := t.TempDir()
+	storage := NewLocalStorage(dataDir)
+
+	// A decoy outside the media tree must survive every hostile operation.
+	if err := os.WriteFile(filepath.Join(dataDir, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed decoy: %v", err)
+	}
+
+	for _, name := range []string{"../evil.txt", "media/../../evil.txt", "/tmp/evil.txt", ".."} {
+		if _, err := storage.Upload(strings.NewReader("evil"), name, ""); err == nil {
+			t.Errorf("Upload(%q): expected error, got nil", name)
+		}
+		// Delete cannot escape either: filepath.Base neutralizes traversal
+		// segments (missing files stay "not an error"), the ".." name is
+		// rejected outright, and os.Root confines the removal; the decoy must
+		// survive all of them.
+		for _, url := range []string{"/uploads/" + name, name} {
+			err := storage.Delete(url)
+			if name == ".." {
+				if err == nil {
+					t.Errorf("Delete(%q): expected error, got nil", url)
+				}
+				continue
+			}
+			if err != nil {
+				t.Errorf("Delete(%q): unexpected error %v", url, err)
+			}
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, "secret.txt")); err != nil {
+		t.Errorf("decoy file was disturbed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "evil.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("evil.txt must not exist outside media")
+	}
+}

--- a/backend/internal/upload/service.go
+++ b/backend/internal/upload/service.go
@@ -70,11 +70,18 @@ func (s *Service) Delete(ctx context.Context, id string, userID uint) error {
 		return ErrNotFound
 	}
 
+	// Look up the acting user's role. A lookup failure must not bypass the
+	// ownership check — failing closed here means a transient DB error can
+	// only block a delete, never widen it.
 	user, err := s.repo.FindUserByID(ctx, userID)
-	if err == nil {
-		if !model.IsAdmin(user.Role) && media.UserID != userID {
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrForbidden
 		}
+		return fmt.Errorf("failed to look up acting user: %w", err)
+	}
+	if !model.IsAdmin(user.Role) && media.UserID != userID {
+		return ErrForbidden
 	}
 
 	// Delete the underlying file; log but continue to delete the DB record

--- a/backend/internal/upload/service_test.go
+++ b/backend/internal/upload/service_test.go
@@ -133,3 +133,42 @@ func TestDelete_PermissionsAndFileRemoval(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+// failingUserLookupRepo forces FindUserByID to fail with an unexpected error
+// to exercise the fail-closed authorization path in Delete.
+type failingUserLookupRepo struct {
+	Repository
+}
+
+func (f failingUserLookupRepo) FindUserByID(context.Context, uint) (*model.User, error) {
+	return nil, errors.New("database is unavailable")
+}
+
+// TestDelete_UserLookupFailureFailsClosed ensures a transient failure while
+// looking up the acting user can never bypass the ownership check: the delete
+// must fail, not proceed.
+func TestDelete_UserLookupFailureFailsClosed(t *testing.T) {
+	svc, _, db := newTestService(t)
+	owner := seedUser(t, db, "owner", model.RoleContributor)
+
+	media, err := svc.Upload(context.Background(), owner.ID, "keep.jpg", 1, strings.NewReader("x"))
+	if err != nil {
+		t.Fatalf("Upload error: %v", err)
+	}
+
+	svc.repo = failingUserLookupRepo{Repository: svc.repo}
+
+	idStr := strconv.FormatUint(uint64(media.ID), 10)
+	if err := svc.Delete(context.Background(), idStr, owner.ID); err == nil || errors.Is(err, ErrForbidden) {
+		t.Errorf("expected a non-forbidden error (fail closed), got %v", err)
+	}
+
+	// the media record must still exist
+	var count int64
+	if err := db.Model(&model.MediaFile{}).Count(&count).Error; err != nil {
+		t.Fatalf("count error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected media record preserved after failed delete, got %d", count)
+	}
+}

--- a/backend/internal/upload/storage.go
+++ b/backend/internal/upload/storage.go
@@ -3,6 +3,7 @@ package upload
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -139,17 +140,40 @@ func NewLocalStorage(dataDir string) *LocalStorage {
 	return &LocalStorage{dataDir: dataDir}
 }
 
+// mediaRoot opens an os.Root over the data directory. Every media file
+// operation goes through it so a hostile filename (absolute path, ".."
+// segment, volume name) can never resolve outside the media tree — the
+// containment is enforced at the OS level, not by string checks.
+func (s *LocalStorage) mediaRoot() (*os.Root, error) {
+	if err := os.MkdirAll(s.dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %w", err)
+	}
+	root, err := os.OpenRoot(s.dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open data directory: %w", err)
+	}
+	return root, nil
+}
+
 // Upload writes the file to the local media directory.
 func (s *LocalStorage) Upload(reader io.Reader, filename, contentType string) (string, error) {
-	uploadDir := filepath.Join(s.dataDir, "media")
-	if _, err := os.Stat(uploadDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(uploadDir, os.ModePerm); err != nil {
-			return "", fmt.Errorf("failed to create upload directory: %w", err)
-		}
+	root, err := s.mediaRoot()
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+
+	// Reject path separators in the (server-generated) filename up front so
+	// the error message is accurate; os.Root would contain them anyway.
+	if strings.ContainsRune(filename, '/') || strings.ContainsRune(filename, '\\') {
+		return "", fmt.Errorf("invalid filename: %s", filename)
 	}
 
-	fullPath := filepath.Join(uploadDir, filename)
-	dst, err := os.Create(fullPath)
+	if err := root.MkdirAll("media", 0o755); err != nil {
+		return "", fmt.Errorf("failed to create upload directory: %w", err)
+	}
+
+	dst, err := root.Create("media/" + filename)
 	if err != nil {
 		return "", fmt.Errorf("failed to create file: %w", err)
 	}
@@ -165,16 +189,20 @@ func (s *LocalStorage) Upload(reader io.Reader, filename, contentType string) (s
 // Delete removes a local file identified by its /uploads/ URL. Missing files
 // are not an error.
 func (s *LocalStorage) Delete(url string) error {
+	root, err := s.mediaRoot()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
 	filename := filepath.Base(url)
-	if filename == "" || filename == "/" {
+	if filename == "" || filename == "/" || filename == "." || filename == ".." ||
+		filename == string(filepath.Separator) {
 		return fmt.Errorf("invalid filename: %s", url)
 	}
 
-	path := filepath.Join(s.dataDir, "media", filename)
-	if _, err := os.Stat(path); err == nil {
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("failed to delete file: %w", err)
-		}
+	if err := root.Remove("media/" + filename); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to delete file: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -26,14 +26,7 @@ func NewHandler(deps Deps) *Handler {
 // GetUserList gets user list
 func (h *Handler) GetUserList(c *gin.Context) {
 	// Pagination parameters
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
-	if page < 1 {
-		page = 1
-	}
-	if limit < 1 || limit > 100 {
-		limit = 10
-	}
+	page, limit := middleware.ParsePagination(c, 10)
 
 	search := c.DefaultQuery("search", "")
 
@@ -191,17 +184,9 @@ func (h *Handler) GetCreatorApplications(c *gin.Context) {
 		return
 	}
 
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	page, limit := middleware.ParsePagination(c, 10)
 	statusStr := c.DefaultQuery("status", string(model.CreatorApplicationStatusPending))
 	status := model.CreatorApplicationStatus(statusStr)
-
-	if page < 1 {
-		page = 1
-	}
-	if limit < 1 || limit > 100 {
-		limit = 10
-	}
 
 	applications, total, err := h.svc.ListCreatorApplications(c.Request.Context(), ListCreatorApplicationsQuery{
 		ActorRole: actor.Role,


### PR DESCRIPTION
## Changes

### Account takeover (high)

- **Predictable account tokens.** Password-reset / email-verification / email-change tokens were `userID-nanosecond` — guessable within their 5-minute window. Now 256 bits of `crypto/rand` (base64url), and only their SHA-256 hash is stored; lookups hash the presented token, so a DB leak no longer yields live one-time links. Empty token lookups are rejected explicitly instead of relying on handler-level `binding:"required"`.
- **SSO account linking.** An SSO identity carrying a victim's email could log in as them. Linking by email now requires the provider to confirm the address (GitHub `/user/emails` verified flag, Google/OIDC `email_verified` claim) **and** the local account to be verified (unless SMTP is disabled, where no verification flow exists).
- **Password reset invalidates sessions.** `ResetPassword` now bumps `password_version`, so a stolen JWT dies with the reset instead of surviving up to 7 days.
- **Captcha replay.** Login/register accepted already-used captchas, so one solved slider could be replayed until expiry. Challenges are now consumed (deleted) at the sensitive action itself; failed attempts invalidate too.

### Injection / traversal (high–medium)

- **Theme zip extraction.** Entry names were only checked for a literal `..` — absolute paths, drive letters and backslash traversal slipped through. Now pre-checked (`filepath.Clean` + `IsAbs` + `..` scan) and extracted through `os.Root`, which confines every file operation at the OS level.
- **Theme metadata paths.** The uploaded `vexgo-theme.json` `id` was joined into the target directory and passed to `os.RemoveAll` (arbitrary directory delete/write); the `preview` value was served via `c.File` (arbitrary file read, on an unauthenticated route). The ID is now allow-listed to `[A-Za-z0-9_-]`, and the preview path is contained with `public.IsPathInside`.
- **Upload filename / storage.** The client-supplied extension is sanitized to 1–9 alphanumeric characters (previously any suffix after the last dot was kept); `LocalStorage` create/delete now run through `os.Root` and reject traversal names outright.
- **Avatar deletion (IDOR via URL).** Changing the avatar deleted the file behind the old avatar URL verbatim — a client-controlled value that `ExtractS3Key` resolves to any S3 key. The URL is now resolved back to its `media_files` row and deleted only when it is owned by the acting user.

### Hardening (medium)

- **Rate limiting** on the unauthenticated credential endpoints (register, login, password reset, verification resend) via new `auth_rate_limit_per_minute` (default 10/min/IP); captcha brute-force and mail-bombing no longer depend on captcha being enabled.
- **Pagination clamps.** Shared `middleware.ParsePagination` (page ≥ 1, limit 1–100). Previously `?limit=0` panicked (divide-by-zero, reachable unauthenticated on popular/latest posts) and `limit=-1` dropped GORM's `LIMIT` clause entirely (full-table dump).
- **Security headers** (`X-Content-Type-Options: nosniff`, `X-Frame-Options`, `Referrer-Policy`) on every response — none were set before; **http.Server timeouts** (read/header/write/idle, MaxHeaderBytes) against slow-loris.
- **SSO state cache** is swept on issue (previously unbounded growth on an unauthenticated endpoint), and `crypto/rand` errors are checked.
- **Data directory** created with 0750 instead of 0777 (`os.ModePerm`) — it holds `blog.db`.
- **Fail-closed media delete** when the acting user cannot be looked up (previously skipped the ownership check).

### Info disclosure (low–medium)

- SSR post pages (`/posts/:slug`, `/post/:slug`) only render **published** posts — drafts/pending/rejected were served to anyone with the slug.
- SSO discovery / exchange / account-resolution errors return generic messages (details logged server-side); raw provider responses no longer reach the client.
- Access logs redact `?token=...` (live verification/reset links were logged in full), and the email-change token is no longer written to debug logs.

### Minor

- `comment` postId: out-of-range numeric values and unparseable strings now return 400 instead of wrapping into garbage IDs / falling through with 0.