### PR TITLE
chore(flake): add `gotools` in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
               go
               gofumpt
               golangci-lint
+              gotools
               just
               nodejs
               oxlint


### PR DESCRIPTION
## Description

This PR added `gotools` into the dev shell, including `deadcode`.
