### PR TITLE
fix(post): list all published posts in the home page

### DIFF
--- a/backend/internal/post/repository.go
+++ b/backend/internal/post/repository.go
@@ -215,23 +215,6 @@ func (r *gormRepository) listPage(query *gorm.DB, page, limit int) ([]model.Post
 	return posts, total, nil
 }
 
-// applyListVisibility narrows the query to posts visible to the given role.
-func applyListVisibility(query *gorm.DB, userRole string, userID uint) *gorm.DB {
-	switch userRole {
-	case "", model.RoleGuest:
-		return query.Where("status = ?", model.PostStatusPublished)
-	case model.RoleContributor:
-		return query.Where(
-			query.Session(&gorm.Session{}).Where("status = ?", model.PostStatusPublished).
-				Or("author_id = ? AND status != ?", userID, model.PostStatusRejected),
-		)
-	case model.RoleAuthor, model.RoleAdmin, model.RoleSuperAdmin:
-		return query.Where("status != ?", model.PostStatusRejected)
-	default:
-		return query.Where("status = ?", model.PostStatusPublished)
-	}
-}
-
 // applyUserPostsVisibility narrows a user's posts to those visible to the
 // acting role; contributors see all of their own posts.
 func applyUserPostsVisibility(query *gorm.DB, userRole string, authorID, currentUserID uint) *gorm.DB {
@@ -249,7 +232,7 @@ func applyUserPostsVisibility(query *gorm.DB, userRole string, authorID, current
 }
 
 func (r *gormRepository) List(ctx context.Context, userRole string, userID uint, f ListFilter) ([]model.Post, int64, error) {
-	query := applyListVisibility(r.baseQuery(ctx), userRole, userID)
+	query := r.baseQuery(ctx).Where("status = ?", model.PostStatusPublished)
 
 	// Category filter (by id or name)
 	if f.CategoryID != "" {

--- a/backend/internal/post/service_test.go
+++ b/backend/internal/post/service_test.go
@@ -356,12 +356,16 @@ func TestList_RoleVisibility(t *testing.T) {
 		t.Fatalf("Create error: %v", err)
 	}
 
+	// The public List returns every published post regardless of the
+	// caller's role (see repository.List: status = published only). The
+	// contributor's own pending post is therefore not visible here; the
+	// contributor's own pending post is visible in MyPosts.
 	_, total, err = svc.List(ctx, ListQuery{UserRole: contributor.Role, UserID: contributor.ID, Page: 1, Limit: 10})
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
-	if total != 3 {
-		t.Errorf("expected 3 visible posts, got %d", total)
+	if total != 2 {
+		t.Errorf("expected 2 published posts visible to contributor, got %d", total)
 	}
 }
 


### PR DESCRIPTION
## Description

Listed posts in the home page are based on role before, where super admin, admin, and author could view all posts whose status is not rejected.

This PR fixed this issue by showing all published posts in every user's home page.
