### PR TITLE
fix(frontend): clear unread notification badge immediately

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -109,6 +109,7 @@
               "useFormField",
               "useSidebar",
               "useAuth",
+              "useNotifications",
               "useTranslation"
             ]
           }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
+import { NotificationProvider } from "@/hooks/useNotifications";
 import { I18nProvider } from "@/lib/I18nContext";
 import { Layout } from "@/components/Layout";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
@@ -58,153 +59,155 @@ function App() {
     <AuthProvider>
       <I18nProvider>
         <Router>
-          <Layout>
-            <Routes>
-              {/* Public routes */}
-              <Route path="/" element={<HomePage />} />
-              <Route path="/post/:slug" element={<PostDetailPage />} />
-              <Route path="/user/:id" element={<UserPostsPage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/register" element={<RegisterPage />} />
-              <Route path="/reset-password" element={<ResetPasswordPage />} />
-              <Route path="/verify-email" element={<VerifyEmailPage />} />
+          <NotificationProvider>
+            <Layout>
+              <Routes>
+                {/* Public routes */}
+                <Route path="/" element={<HomePage />} />
+                <Route path="/post/:slug" element={<PostDetailPage />} />
+                <Route path="/user/:id" element={<UserPostsPage />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/register" element={<RegisterPage />} />
+                <Route path="/reset-password" element={<ResetPasswordPage />} />
+                <Route path="/verify-email" element={<VerifyEmailPage />} />
 
-              {/* Routes requiring login */}
-              <Route
-                path="/write"
-                element={
-                  <ProtectedRoute>
-                    <WritePostPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/edit-post/:id"
-                element={
-                  <ProtectedRoute>
-                    <WritePostPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  <ProtectedRoute>
-                    <ProfilePage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/my-posts"
-                element={
-                  <ProtectedRoute>
-                    <MyPostsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/notifications"
-                element={
-                  <ProtectedRoute>
-                    <NotificationCenterPage />
-                  </ProtectedRoute>
-                }
-              />
+                {/* Routes requiring login */}
+                <Route
+                  path="/write"
+                  element={
+                    <ProtectedRoute>
+                      <WritePostPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/edit-post/:id"
+                  element={
+                    <ProtectedRoute>
+                      <WritePostPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/profile"
+                  element={
+                    <ProtectedRoute>
+                      <ProfilePage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/my-posts"
+                  element={
+                    <ProtectedRoute>
+                      <MyPostsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/notifications"
+                  element={
+                    <ProtectedRoute>
+                      <NotificationCenterPage />
+                    </ProtectedRoute>
+                  }
+                />
 
-              <Route
-                path="/settings"
-                element={
-                  <ProtectedRoute>
-                    <SettingsPage />
-                  </ProtectedRoute>
-                }
-              />
+                <Route
+                  path="/settings"
+                  element={
+                    <ProtectedRoute>
+                      <SettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
 
-              {/* Routes requiring admin access */}
-              <Route
-                path="/admin"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <AdminPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/moderation"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <ModerationPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/users"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <UserManagementPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/smtp"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <SMTPSettingsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/general-settings"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <GeneralSettingsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/comment-moderation"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <CommentModerationPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/comment-config"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <CommentConfigPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/ai-settings"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <AISettingsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/theme"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <ThemePage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/creator-applications"
-                element={
-                  <ProtectedRoute requireAdmin>
-                    <CreatorApplicationReviewPage />
-                  </ProtectedRoute>
-                }
-              />
-              {/* Catch-all 404 */}
-              <Route path="*" element={<NotFoundPage />} />
-            </Routes>
-          </Layout>
+                {/* Routes requiring admin access */}
+                <Route
+                  path="/admin"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <AdminPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/moderation"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <ModerationPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/users"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <UserManagementPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/smtp"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <SMTPSettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/general-settings"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <GeneralSettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/comment-moderation"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <CommentModerationPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/comment-config"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <CommentConfigPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/ai-settings"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <AISettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/theme"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <ThemePage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/creator-applications"
+                  element={
+                    <ProtectedRoute requireAdmin>
+                      <CreatorApplicationReviewPage />
+                    </ProtectedRoute>
+                  }
+                />
+                {/* Catch-all 404 */}
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </Layout>
+          </NotificationProvider>
         </Router>
         <Toaster />
       </I18nProvider>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
-import { configApi, notificationsApi } from "@/lib/api";
+import { useNotifications } from "@/hooks/useNotifications";
+import { configApi } from "@/lib/api";
 import { useTranslation } from "@/lib/I18nContext";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +35,7 @@ interface LayoutProps {
 export function Layout({ children }: LayoutProps) {
   const { t } = useTranslation();
   const { user, isAuthenticated, logout } = useAuth();
+  const { unreadCount } = useNotifications();
   const navigate = useNavigate();
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
@@ -98,49 +100,6 @@ export function Layout({ children }: LayoutProps) {
     logout();
     navigate("/");
   };
-
-  // Unread notification count
-  const [unreadCount, setUnreadCount] = useState(0);
-
-  // Fetch the unread notification count
-  const fetchUnreadCount = async () => {
-    try {
-      const response = await notificationsApi.getUnreadCount();
-      setUnreadCount(response.data.unreadCount);
-    } catch (error) {
-      console.error("Failed to fetch the unread notification count:", error);
-    }
-  };
-
-  useEffect(() => {
-    // Only fetch the unread count when logged in
-    if (isAuthenticated) {
-      fetchUnreadCount();
-    }
-  }, [isAuthenticated]);
-
-  // Periodically refresh the unread count (every 30s)
-  useEffect(() => {
-    let interval: ReturnType<typeof setInterval>;
-    if (isAuthenticated) {
-      interval = setInterval(() => {
-        fetchUnreadCount();
-      }, 30000); // check every 30 seconds
-    }
-    return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
-  }, [isAuthenticated]);
-
-  // Refresh the unread count on route changes, e.g. when entering or leaving the notifications page
-  useEffect(() => {
-    if (isAuthenticated) {
-      // Check the unread count whenever the route changes
-      fetchUnreadCount();
-    }
-  }, [isAuthenticated, location.pathname]);
 
   const navItems = [
     { path: "/", label: t("layout.home"), icon: Home },

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -1,0 +1,100 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { useLocation } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import { notificationsApi } from "@/lib/api";
+
+interface NotificationContextType {
+  unreadCount: number;
+  refreshUnreadCount: () => Promise<void>;
+  decrementUnreadCount: () => void;
+  clearUnreadCount: () => void;
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(
+  undefined,
+);
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  // Fetch the unread notification count from the backend.
+  const refreshUnreadCount = async () => {
+    try {
+      const response = await notificationsApi.getUnreadCount();
+      setUnreadCount(response.data.unreadCount);
+    } catch (error) {
+      console.error("Failed to fetch the unread notification count:", error);
+    }
+  };
+
+  // Optimistically reduce the unread count by one, never below zero.
+  const decrementUnreadCount = () => {
+    setUnreadCount((count) => Math.max(0, count - 1));
+  };
+
+  // Optimistically reset the unread count to zero.
+  const clearUnreadCount = () => {
+    setUnreadCount(0);
+  };
+
+  // Fetch the unread count when the user logs in.
+  useEffect(() => {
+    if (isAuthenticated) {
+      refreshUnreadCount();
+    }
+  }, [isAuthenticated]);
+
+  // Periodically refresh the unread count (every 30s).
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval>;
+    if (isAuthenticated) {
+      interval = setInterval(() => {
+        refreshUnreadCount();
+      }, 30000); // check every 30 seconds
+    }
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [isAuthenticated]);
+
+  // Refresh the unread count on route changes, e.g. when entering or leaving
+  // the notifications page.
+  useEffect(() => {
+    if (isAuthenticated) {
+      refreshUnreadCount();
+    }
+  }, [isAuthenticated, location.pathname]);
+
+  return (
+    <NotificationContext.Provider
+      value={{
+        unreadCount,
+        refreshUnreadCount,
+        decrementUnreadCount,
+        clearUnreadCount,
+      }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  const context = useContext(NotificationContext);
+  if (context === undefined) {
+    throw new Error(
+      "useNotifications must be used within a NotificationProvider",
+    );
+  }
+  return context;
+}

--- a/frontend/src/pages/NotificationCenterPage.tsx
+++ b/frontend/src/pages/NotificationCenterPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
+import { useNotifications } from "@/hooks/useNotifications";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -47,6 +48,7 @@ type Notification = {
 export function NotificationCenterPage() {
   const { t } = useTranslation();
   const { user } = useAuth();
+  const { decrementUnreadCount, clearUnreadCount } = useNotifications();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("all");
 
@@ -119,6 +121,9 @@ export function NotificationCenterPage() {
 
   // Mark a notification as read
   const markAsRead = async (id: string) => {
+    const wasUnread = notifications.some(
+      (notification) => notification.id === id && !notification.isRead,
+    );
     try {
       await notificationsApi.markAsRead(id);
       // Update the local state
@@ -129,6 +134,9 @@ export function NotificationCenterPage() {
             : notification,
         ),
       );
+      if (wasUnread) {
+        decrementUnreadCount();
+      }
     } catch (error) {
       console.error(t("errors.networkError"), error);
     }
@@ -142,6 +150,7 @@ export function NotificationCenterPage() {
       setNotifications((prev) =>
         prev.map((notification) => ({ ...notification, isRead: true })),
       );
+      clearUnreadCount();
     } catch (error) {
       console.error(t("errors.networkError"), error);
     }
@@ -149,12 +158,18 @@ export function NotificationCenterPage() {
 
   // Delete a notification
   const deleteNotification = async (id: string) => {
+    const wasUnread = notifications.some(
+      (notification) => notification.id === id && !notification.isRead,
+    );
     try {
       await notificationsApi.deleteNotification(id);
       // Update the local state
       setNotifications((prev) =>
         prev.filter((notification) => notification.id !== id),
       );
+      if (wasUnread) {
+        decrementUnreadCount();
+      }
     } catch (error) {
       console.error(t("errors.networkError"), error);
     }


### PR DESCRIPTION
## Motivation

Marking all notifications as read did not update the navbar unread-count
badge until a page refresh (or a route change / the 30s polling interval).
This makes the badge disappear immediately.

## Implementation summary

- Added a shared `NotificationProvider` (`frontend/src/hooks/useNotifications.tsx`)
  that owns the unread count and exposes `refreshUnreadCount`,
  `decrementUnreadCount`, and `clearUnreadCount`.
- Moved the existing unread-count polling (on login, every 30s, and on route
  change) out of `Layout` into the provider.
- `Layout` now reads the count from the provider instead of local state.
- `NotificationCenterPage` calls `clearUnreadCount()` after "mark all as read",
  and `decrementUnreadCount()` after marking a single notification read or
  deleting an unread one.
- Added `useNotifications` to oxlint's `allowExportNames` for
  `react/only-export-components`.

## Key invariants

- The badge count only decrements when the affected notification was unread.
- `decrementUnreadCount` clamps at zero to avoid negative counts.

## Edge cases

- Marking an already-read notification as read does not decrement the count.
- Deleting a read notification does not decrement the count.
- Unauthenticated users never fetch or render the badge.

## Verification steps

- `pnpm run build` (tsc -b + vite) — passed
- `pnpm run lint` (oxlint --deny-warnings) — passed
- `npx prettier --check` on changed files — passed
- `go test -count=1 ./...` — passed (frontend-only change)
- Manual: two accounts (author + commenter) — after "mark all as read" the
  badge disappears immediately without refresh.

## Linked issues

<!-- 若任务是大问题(Issue)则写 Closes #<issue号>；若是 Draft 则删掉此行 -->
