### PR TITLE
chore(lint): declare `denyWarnings` in `.oxlintrc.json` instead of passing by cli flag

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -9,6 +9,7 @@
   },
   "ignorePatterns": ["dist"],
   "options": {
+    "denyWarnings": true,
     "typeAware": true,
     "typeCheck": true
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build && node scripts/copy-manifest.mjs",
-    "lint": "oxlint --deny-warnings .",
+    "lint": "oxlint .",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ lint:
     output=$(deadcode -test ./...); test -z "$output" || { echo "$output"; exit 1;}
     prettier --check "**/*.{js,jsx,ts,tsx,html,md}" "frontend/*.json" "./*.{json,yml,yaml}"
     diffs="$(gofumpt -d .)"; test -z "$diffs" || { echo "$diffs"; exit 1; }
-    oxlint --deny-warnings -c frontend/.oxlintrc.json frontend/
+    oxlint -c frontend/.oxlintrc.json frontend/
     output=$(gopls check -severity=hint ./**/*.go); test -z "$output" || { echo "$output"; exit 1;}
 
 test:


### PR DESCRIPTION
## Description

`oxlint` supports declaring `denyWarnings` in `.oxlintrc.json`. To keep the lint command simple, this PR removed `--deny-warnings` flag and enabled `denyWarnings` option in `.oxlintrc.json`.
