### PR TITLE
refactor(storage): thread context through `Storage/FileRemover`, drop TODOs

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -262,6 +262,9 @@ func initStorage(cfg *config.Config) (upload.Storage, error) {
 		return storage, nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	s3Cfg := &config.S3Config{
 		Enabled:                  cfg.S3Enabled,
 		Endpoint:                 cfg.S3Endpoint,
@@ -281,7 +284,7 @@ func initStorage(cfg *config.Config) (upload.Storage, error) {
 		"bucket", s3Cfg.Bucket,
 	)
 
-	s3Storage, err := upload.NewS3Storage(s3Cfg)
+	s3Storage, err := upload.NewS3Storage(ctx, s3Cfg)
 	if err != nil {
 		return nil, fmt.Errorf("init S3 storage: %w", err)
 	}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -508,7 +508,7 @@ func (s *Service) deleteOldAvatar(ctx context.Context, userID uint, url string) 
 		slog.Warn("old avatar media record belongs to another user, skipping deletion", "userID", userID, "ownerID", media.UserID, "url", url)
 		return
 	}
-	if err := s.files.Delete(url); err != nil {
+	if err := s.files.Delete(ctx, url); err != nil {
 		slog.Warn("failed to delete old avatar", "url", url, "err", err)
 	}
 }

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -47,7 +47,7 @@ type fakeFiles struct {
 	deleted []string
 }
 
-func (f *fakeFiles) Delete(url string) error {
+func (f *fakeFiles) Delete(_ context.Context, url string) error {
 	f.deleted = append(f.deleted, url)
 	return nil
 }

--- a/backend/internal/model/interfaces.go
+++ b/backend/internal/model/interfaces.go
@@ -23,5 +23,5 @@ type Notifier interface {
 // FileRemover deletes a stored file by its public URL; implemented by
 // upload.Storage and injected so it can be faked in tests.
 type FileRemover interface {
-	Delete(url string) error
+	Delete(ctx context.Context, url string) error
 }

--- a/backend/internal/post/service_post.go
+++ b/backend/internal/post/service_post.go
@@ -357,7 +357,7 @@ func (s *Service) Delete(ctx context.Context, id string, userID uint) error {
 		uniqueImages[url] = true
 	}
 	for url := range uniqueImages {
-		if err := s.files.Delete(url); err != nil {
+		if err := s.files.Delete(ctx, url); err != nil {
 			slog.Warn(
 				"failed to delete image",
 				"url", url,

--- a/backend/internal/post/service_test.go
+++ b/backend/internal/post/service_test.go
@@ -26,7 +26,7 @@ type fakeRemover struct {
 	deleted []string
 }
 
-func (f *fakeRemover) Delete(url string) error {
+func (f *fakeRemover) Delete(_ context.Context, url string) error {
 	f.deleted = append(f.deleted, url)
 	return nil
 }

--- a/backend/internal/upload/handler_test.go
+++ b/backend/internal/upload/handler_test.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func TestLocalStorage_ContainsHostileFilenames(t *testing.T) {
 	}
 
 	for _, name := range []string{"../evil.txt", "media/../../evil.txt", "/tmp/evil.txt", ".."} {
-		if _, err := storage.Upload(strings.NewReader("evil"), name, ""); err == nil {
+		if _, err := storage.Upload(context.Background(), strings.NewReader("evil"), name, ""); err == nil {
 			t.Errorf("Upload(%q): expected error, got nil", name)
 		}
 		// Delete cannot escape either: filepath.Base neutralizes traversal
@@ -80,7 +81,7 @@ func TestLocalStorage_ContainsHostileFilenames(t *testing.T) {
 		// rejected outright, and os.Root confines the removal; the decoy must
 		// survive all of them.
 		for _, url := range []string{"/uploads/" + name, name} {
-			err := storage.Delete(url)
+			err := storage.Delete(context.Background(), url)
 			if name == ".." {
 				if err == nil {
 					t.Errorf("Delete(%q): expected error, got nil", url)

--- a/backend/internal/upload/service.go
+++ b/backend/internal/upload/service.go
@@ -40,7 +40,7 @@ func NewService(deps Deps) *Service {
 
 // Upload stores a file and records it in the database.
 func (s *Service) Upload(ctx context.Context, userID uint, filename string, size int64, src io.Reader) (model.MediaFile, error) {
-	url, err := s.storage.Upload(src, filename, "")
+	url, err := s.storage.Upload(ctx, src, filename, "")
 	if err != nil {
 		return model.MediaFile{}, err
 	}
@@ -85,7 +85,7 @@ func (s *Service) Delete(ctx context.Context, id string, userID uint) error {
 	}
 
 	// Delete the underlying file; log but continue to delete the DB record
-	if err := s.storage.Delete(media.URL); err != nil {
+	if err := s.storage.Delete(ctx, media.URL); err != nil {
 		slog.Warn("failed to delete file", "err", err)
 	}
 

--- a/backend/internal/upload/storage.go
+++ b/backend/internal/upload/storage.go
@@ -22,10 +22,10 @@ import (
 type Storage interface {
 	// Upload stores the file content under a generated key and returns its
 	// public URL.
-	Upload(reader io.Reader, filename, contentType string) (string, error)
+	Upload(ctx context.Context, reader io.Reader, filename, contentType string) (string, error)
 	// Delete removes the file identified by its public URL. Missing files are
 	// not an error.
-	Delete(url string) error
+	Delete(ctx context.Context, url string) error
 }
 
 // S3Storage stores files in an S3-compatible bucket.
@@ -36,7 +36,7 @@ type S3Storage struct {
 
 // NewS3Storage initializes the MinIO client and verifies the bucket,
 // mirroring the previous handler.InitS3 behavior.
-func NewS3Storage(cfg *config.S3Config) (*S3Storage, error) {
+func NewS3Storage(ctx context.Context, cfg *config.S3Config) (*S3Storage, error) {
 	if !cfg.IsEnabled() {
 		return nil, nil
 	}
@@ -67,7 +67,7 @@ func NewS3Storage(cfg *config.S3Config) (*S3Storage, error) {
 	}
 
 	// Verify connectivity by checking if the target bucket exists
-	exists, err := client.BucketExists(context.TODO(), cfg.Bucket)
+	exists, err := client.BucketExists(ctx, cfg.Bucket)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to S3: %w", err)
 	}
@@ -82,7 +82,7 @@ func NewS3Storage(cfg *config.S3Config) (*S3Storage, error) {
 // Upload uploads a file to the configured S3 bucket.
 // Passing size as -1 lets minio-go handle multipart upload automatically.
 // Returns the public URL of the uploaded file.
-func (s *S3Storage) Upload(reader io.Reader, filename, contentType string) (string, error) {
+func (s *S3Storage) Upload(ctx context.Context, reader io.Reader, filename, contentType string) (string, error) {
 	if s.client == nil {
 		return "", fmt.Errorf("S3 storage not initialized")
 	}
@@ -92,7 +92,7 @@ func (s *S3Storage) Upload(reader io.Reader, filename, contentType string) (stri
 		contentType = detectContentType(filename)
 	}
 
-	_, err := s.client.PutObject(context.TODO(), s.cfg.Bucket, filename, reader, -1, minio.PutObjectOptions{
+	_, err := s.client.PutObject(ctx, s.cfg.Bucket, filename, reader, -1, minio.PutObjectOptions{
 		ContentType: contentType,
 	})
 	if err != nil {
@@ -106,27 +106,27 @@ func (s *S3Storage) Upload(reader io.Reader, filename, contentType string) (stri
 
 // Delete removes an object from the configured S3 bucket by extracting the key
 // from its public URL (with a filename fallback).
-func (s *S3Storage) Delete(url string) error {
+func (s *S3Storage) Delete(ctx context.Context, url string) error {
 	if s.client == nil {
 		return fmt.Errorf("S3 storage not initialized")
 	}
 
 	key := ExtractS3Key(url, s.cfg)
 	if key != "" {
-		return s.remove(key)
+		return s.remove(ctx, key)
 	}
 
 	// If key extraction failed, try to delete using filename as key (fallback)
 	filename := filepath.Base(url)
 	if filename != "" && filename != "/" {
-		return s.remove(filename)
+		return s.remove(ctx, filename)
 	}
 	return fmt.Errorf("invalid S3 key from URL: %s", url)
 }
 
 // remove deletes the object with the given key from the configured bucket.
-func (s *S3Storage) remove(key string) error {
-	return s.client.RemoveObject(context.TODO(), s.cfg.Bucket, key, minio.RemoveObjectOptions{})
+func (s *S3Storage) remove(ctx context.Context, key string) error {
+	return s.client.RemoveObject(ctx, s.cfg.Bucket, key, minio.RemoveObjectOptions{})
 }
 
 // LocalStorage stores files under <dataDir>/media and serves them at
@@ -156,7 +156,7 @@ func (s *LocalStorage) mediaRoot() (*os.Root, error) {
 }
 
 // Upload writes the file to the local media directory.
-func (s *LocalStorage) Upload(reader io.Reader, filename, contentType string) (string, error) {
+func (s *LocalStorage) Upload(_ context.Context, reader io.Reader, filename, contentType string) (string, error) {
 	root, err := s.mediaRoot()
 	if err != nil {
 		return "", err
@@ -188,7 +188,7 @@ func (s *LocalStorage) Upload(reader io.Reader, filename, contentType string) (s
 
 // Delete removes a local file identified by its /uploads/ URL. Missing files
 // are not an error.
-func (s *LocalStorage) Delete(url string) error {
+func (s *LocalStorage) Delete(_ context.Context, url string) error {
 	root, err := s.mediaRoot()
 	if err != nil {
 		return err

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -170,7 +170,7 @@ func (s *Service) DeleteUser(ctx context.Context, actor model.User, targetID uin
 	}
 
 	for _, url := range fileURLs {
-		if err := s.files.Delete(url); err != nil {
+		if err := s.files.Delete(ctx, url); err != nil {
 			slog.Warn(
 				"failed to delete media file",
 				"url", url,

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -29,7 +29,7 @@ type fakeFiles struct {
 	deleted []string
 }
 
-func (f *fakeFiles) Delete(url string) error {
+func (f *fakeFiles) Delete(_ context.Context, url string) error {
 	f.deleted = append(f.deleted, url)
 	return nil
 }


### PR DESCRIPTION
## Description

Replace the `context.TODO()` calls in S3Storage with the request context:
`Storage.Upload/Delete` and `model.FileRemover` now take `ctx`, and the
auth/post/user avatar and media cleanup paths pass theirs through.
`NewS3Storage` takes `ctx` for its bucket check; `initStorage` bounds it
with a 10s startup timeout mirroring `initCache`.
