### PR TITLE
refactor(comment): replace `any` with `uint` for `CreateCommentRequest.PostID`

### DIFF
--- a/backend/internal/comment/handler.go
+++ b/backend/internal/comment/handler.go
@@ -3,7 +3,6 @@ package comment
 import (
 	"errors"
 	"log/slog"
-	"math"
 	"net/http"
 	"strconv"
 
@@ -57,8 +56,8 @@ func (h *Handler) GetComments(c *gin.Context) {
 //
 //	@Summary		Create a comment
 //	@Description	Adds a comment to a post. Content is capped at 100
-//	@Description	characters. The postId accepts either a number or a
-//	@Description	string. The reply is held for moderation when the
+//	@Description	characters.
+//	@Description	The reply is held for moderation when the
 //	@Description	manual review queue is on, the keyword filter rejects
 //	@Description	it, or the LLM filter rejects it.
 //	@Tags			comments
@@ -72,7 +71,6 @@ func (h *Handler) GetComments(c *gin.Context) {
 //	@Failure		500		{object}	api.ErrorResponse
 //	@Router			/comments [post]
 func (h *Handler) CreateComment(c *gin.Context) {
-	// Support postId as number or string from frontend
 	var req CreateCommentRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -87,38 +85,6 @@ func (h *Handler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	// Parse PostID to uint
-	var postID uint
-	switch v := req.PostID.(type) {
-	case float64:
-		// JSON numbers decode as float64; reject out-of-range or negative
-		// values instead of letting the conversion wrap into garbage IDs.
-		if v < 1 || v > math.MaxUint32 {
-			c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "Invalid postId"})
-			return
-		}
-		postID = uint(v)
-	case string:
-		id64, err := strconv.ParseUint(v, 10, 64)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "Invalid postId"})
-			return
-		}
-		postID = uint(id64)
-	case int:
-		if v < 1 {
-			c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "Invalid postId"})
-			return
-		}
-		postID = uint(v)
-	case uint:
-		postID = v
-	default:
-		// If cannot parse, return error
-		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "Invalid postId type"})
-		return
-	}
-
 	userID := middleware.CurrentUserID(c)
 	if userID == 0 {
 		// Reject unauthenticated request
@@ -127,7 +93,7 @@ func (h *Handler) CreateComment(c *gin.Context) {
 	}
 
 	comment, count, err := h.svc.Create(c.Request.Context(), CreateRequest{
-		PostID:   postID,
+		PostID:   req.PostID,
 		UserID:   userID,
 		Content:  req.Content,
 		ParentID: req.ParentID,

--- a/backend/internal/comment/handler_test.go
+++ b/backend/internal/comment/handler_test.go
@@ -112,7 +112,7 @@ func TestCreateComment_KeywordReject_ExposesReasonInModerationList(t *testing.T)
 	}
 
 	w = doJSON(t, r, http.MethodPost, "/api/comments", userToken,
-		`{"postId": "`+strconv.FormatUint(uint64(post.ID), 10)+`", "content": "buy spam now"}`)
+		`{"postId": `+strconv.FormatUint(uint64(post.ID), 10)+`, "content": "buy spam now"}`)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("create comment failed: %d %s", w.Code, w.Body.String())
 	}
@@ -288,7 +288,7 @@ func TestModerationQueue_ApproveRejectDelete(t *testing.T) {
 
 	create := func(content string) string {
 		w := doJSON(t, r, http.MethodPost, "/api/comments", userToken,
-			`{"postId": "`+strconv.FormatUint(uint64(post.ID), 10)+`", "content": "`+content+`"}`)
+			`{"postId": `+strconv.FormatUint(uint64(post.ID), 10)+`, "content": "`+content+`"}`)
 		if w.Code != http.StatusCreated {
 			t.Fatalf("create comment failed: %d %s", w.Code, w.Body.String())
 		}

--- a/backend/internal/comment/types.go
+++ b/backend/internal/comment/types.go
@@ -13,11 +13,8 @@ type CommentListResponse struct {
 }
 
 // CreateCommentRequest is the body of POST /api/comments.
-// The postId field accepts either a number or a string; the
-// service layer normalises the type before persisting.
 type CreateCommentRequest struct {
-	// TODO: Consider change the type of `PostID` to `uint`.
-	PostID   any    `json:"postId" binding:"required" swaggertype:"primitive,integer" example:"42"`
+	PostID   uint   `json:"postId" binding:"required" example:"42"`
 	Content  string `json:"content" binding:"required" maxLength:"100" example:"Great post!"`
 	ParentID *uint  `json:"parentId" swaggertype:"primitive,integer" example:"7"`
 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -601,7 +601,6 @@
                         "type": "integer"
                     },
                     "postId": {
-                        "description": "TODO: Consider change the type of `PostID` to `uint`.",
                         "example": 42,
                         "type": "integer"
                     }
@@ -3310,7 +3309,7 @@
         },
         "/comments": {
             "post": {
-                "description": "Adds a comment to a post. Content is capped at 100\ncharacters. The postId accepts either a number or a\nstring. The reply is held for moderation when the\nmanual review queue is on, the keyword filter rejects\nit, or the LLM filter rejects it.",
+                "description": "Adds a comment to a post. Content is capped at 100\ncharacters.\nThe reply is held for moderation when the\nmanual review queue is on, the keyword filter rejects\nit, or the LLM filter rejects it.",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/frontend/src/api/generated/endpoints.ts
+++ b/frontend/src/api/generated/endpoints.ts
@@ -385,8 +385,8 @@ export const getVexGoAPI = () => {
 
   /**
    * Adds a comment to a post. Content is capped at 100
-   * characters. The postId accepts either a number or a
-   * string. The reply is held for moderation when the
+   * characters.
+   * The reply is held for moderation when the
    * manual review queue is on, the keyword filter rejects
    * it, or the LLM filter rejects it.
    * @summary Create a comment

--- a/frontend/src/api/generated/model/commentCreateCommentRequest.ts
+++ b/frontend/src/api/generated/model/commentCreateCommentRequest.ts
@@ -10,6 +10,5 @@ export interface CommentCreateCommentRequest {
   /** @maxLength 100 */
   content: string;
   parentId?: number;
-  /** TODO: Consider change the type of `PostID` to `uint`. */
   postId: number;
 }


### PR DESCRIPTION
## Description

APIs are now generated by `swag`. It is type-safe, so `any` types in API models are no longer needed.

This PR replaced an `any` type in backend API model with a specific type, and re-generated API code.
